### PR TITLE
Add task to scan the package.json and install peer dependencies

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -65,6 +65,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 
 	require('./tasks/updateTsconfig')(grunt);
 	require('./tasks/uploadCoverage')(grunt);
+	require('./tasks/installPeerDependencies')(grunt, packageJson);
 
 	if (otherOptions) {
 		grunt.config.merge(otherOptions);

--- a/tasks/installPeerDependencies.ts
+++ b/tasks/installPeerDependencies.ts
@@ -5,9 +5,9 @@ export = function(grunt: IGrunt, packageJson: any) {
 		const peerDeps = packageJson.peerDependencies;
 
 		for (let name in peerDeps) {
-			grunt.log.write('installing peer dependency ' + name + ' with version ' + peerDeps[name] + '...');
+			grunt.log.write(`installing peer dependency ${name} with version ${peerDeps[name]}...`);
 			try {
-				let cmd = 'npm install ' + name + '@"' + peerDeps[name] + '"';
+				let cmd = `npm install ${name}@"${peerDeps[name]}"`;
 				exec(cmd, { stdio: 'ignore' });
 				grunt.log.ok('complete.');
 			} catch (error) {

--- a/tasks/installPeerDependencies.ts
+++ b/tasks/installPeerDependencies.ts
@@ -1,0 +1,18 @@
+import { execSync as exec } from 'child_process';
+
+export = function(grunt: IGrunt, packageJson: any) {
+	grunt.registerTask('peerDepInstall', <any> function () {
+		const peerDeps = packageJson.peerDependencies;
+
+		for (let name in peerDeps) {
+			grunt.log.write('installing peer dependency ' + name + ' with version ' + peerDeps[name] + '...');
+			try {
+				let cmd = 'npm install ' + name + '@"' + peerDeps[name] + '"';
+				exec(cmd, { stdio: 'ignore' });
+				grunt.log.ok('complete.');
+			} catch (error) {
+				grunt.log.error('failed.');
+			}
+		}
+	});
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
 		"./tasks/rename.ts",
 		"./tasks/updateTsconfig.ts",
 		"./tasks/uploadCoverage.ts",
+		"./tasks/installPeerDependencies.ts",
 		"./typings/index.d.ts"
 	]
 }


### PR DESCRIPTION
Provide a task to install peer dependencies specified in the `package.json`, resolves #5 