### PR TITLE
Add run and repl task to make dojo-loader easier under Node.js

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2

--- a/index.ts
+++ b/index.ts
@@ -66,6 +66,8 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	require('./tasks/updateTsconfig')(grunt);
 	require('./tasks/uploadCoverage')(grunt);
 	require('./tasks/installPeerDependencies')(grunt, packageJson);
+	require('./tasks/repl')(grunt, packageJson);
+	require('./tasks/run')(grunt, packageJson);
 
 	if (otherOptions) {
 		grunt.config.merge(otherOptions);

--- a/lib/load-dojo-loader.ts
+++ b/lib/load-dojo-loader.ts
@@ -1,0 +1,38 @@
+import { join } from 'path';
+
+const resolveFrom = require('resolve-from');
+
+export default function loadDojoLoader ({ peerDependencies = {} }: any) {
+	const baseUrl = process.cwd();
+	const packages = [
+		{ name: 'src', location: '_build/src' }
+	];
+
+	for (const name in peerDependencies) {
+		if (/^dojo-/.test(name)) {
+			packages.push({ name, location: join('node_modules', name, 'dist', 'umd') });
+		}
+		else if (name === '@reactivex/rxjs') {
+			packages.push({ name: 'rxjs', location: join('node_modules', name, 'dist', 'amd') });
+		}
+		else if (name === 'maquette' || name === 'immutable') {
+			packages.push({ name, location: join('node_modules', name, 'dist') });
+		}
+		else {
+			packages.push({ name, location: join('node_modules', name) });
+		}
+	}
+
+	// Assume dojo-loader is installed in the parent project.
+	const r = require(resolveFrom(baseUrl, 'dojo-loader'));
+	r.config({
+		baseUrl,
+		packages
+	});
+
+	return {
+		baseUrl,
+		packages,
+		require: r
+	};
+}

--- a/package.json
+++ b/package.json
@@ -1,49 +1,54 @@
 {
-	"name": "grunt-dojo2",
-	"version": "2.0.0-pre",
-	"description": "A package of Grunt tasks to use with Dojo 2 Packages",
-	"homepage": "http://dojotoolkit.org",
-	"keywords": [ "dojo2", "gruntplugin" ],
-	"bugs": {
-		"url": "https://github.com/dojo/grunt-dojo2/issues"
-	},
-	"main": "index.js",
-	"scripts": {
-		"prepublish": "shx rm -rf ./typings && typings install && tsc -p .",
-		"test": "tests/run.sh"
-	},
-	"author": "Bryan Forbes <bryan@reigndropsfall.net>",
-	"contributors": [ {
-		"name": "Kitson Kelly",
-		"email": "me@kitsonkelly.com"
-	} ],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/dojo/grunt-dojo2.git"
-	},
-	"license": "BSD-3-Clause",
-	"typings": "index.d.ts",
-	"dependencies": {
-		"glob": "^7.0.0",
-		"grunt-typings": ">=0.1.5"
-	},
-	"peerDependencies": {
-		"codecov.io": ">=0.1.6",
-		"dts-generator": ">=1.7.0",
-		"grunt-contrib-clean": ">=1.0.0",
-		"grunt-contrib-copy": ">=1.0.0",
-		"grunt-contrib-watch": ">=1.0.0",
-		"grunt-text-replace": ">=0.4.0",
-		"grunt-ts": ">=5.0.0",
-		"grunt-tslint": ">=3.0.0",
-		"remap-istanbul": ">=0.6.3"
-	},
-	"devDependencies": {
-		"codecov.io": "0.1.6",
-		"grunt": "^1.0.1",
-		"intern": "^3.2.0",
-		"shx": ">=0.1.2",
-		"tslint": "^3.10.1",
-		"typescript": "^1.8.10"
-	}
+  "name": "grunt-dojo2",
+  "version": "2.0.0-pre",
+  "description": "A package of Grunt tasks to use with Dojo 2 Packages",
+  "homepage": "http://dojotoolkit.org",
+  "keywords": [
+    "dojo2",
+    "gruntplugin"
+  ],
+  "bugs": {
+    "url": "https://github.com/dojo/grunt-dojo2/issues"
+  },
+  "main": "index.js",
+  "scripts": {
+    "prepublish": "shx rm -rf ./typings && typings install && tsc -p .",
+    "test": "tests/run.sh"
+  },
+  "author": "Bryan Forbes <bryan@reigndropsfall.net>",
+  "contributors": [
+    {
+      "name": "Kitson Kelly",
+      "email": "me@kitsonkelly.com"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dojo/grunt-dojo2.git"
+  },
+  "license": "BSD-3-Clause",
+  "typings": "index.d.ts",
+  "dependencies": {
+    "glob": "^7.0.0",
+    "grunt-typings": ">=0.1.5"
+  },
+  "peerDependencies": {
+    "codecov.io": ">=0.1.6",
+    "dts-generator": ">=1.7.0",
+    "grunt-contrib-clean": ">=1.0.0",
+    "grunt-contrib-copy": ">=1.0.0",
+    "grunt-contrib-watch": ">=1.0.0",
+    "grunt-text-replace": ">=0.4.0",
+    "grunt-ts": ">=5.0.0",
+    "grunt-tslint": ">=3.0.0",
+    "remap-istanbul": ">=0.6.3"
+  },
+  "devDependencies": {
+    "codecov.io": "0.1.6",
+    "grunt": "^1.0.1",
+    "intern": "^3.2.0",
+    "shx": ">=0.1.2",
+    "tslint": "^3.10.1",
+    "typescript": "^1.8.10"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "typings": "index.d.ts",
   "dependencies": {
     "glob": "^7.0.0",
-    "grunt-typings": ">=0.1.5"
+    "grunt-typings": ">=0.1.5",
+    "resolve-from": "^2.0.0"
   },
   "peerDependencies": {
     "codecov.io": ">=0.1.6",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "intern": "^3.2.0",
     "shx": ">=0.1.2",
     "tslint": "^3.10.1",
-    "typescript": "^1.8.10"
+    "typescript": "^1.8.10",
+    "typings": "^1.3.1"
   }
 }

--- a/tasks/repl.ts
+++ b/tasks/repl.ts
@@ -1,0 +1,43 @@
+const repl = require('repl');
+
+import loadDojoLoader from '../lib/load-dojo-loader';
+
+const resolveFrom = require('resolve-from');
+
+export = function(grunt: IGrunt, packageJson: any) {
+	grunt.registerTask('repl', 'Bootstrap dojo-loader and start a Node.js REPL', function () {
+		this.async(); // Ensure Grunt doesn't exit the process.
+
+		const { baseUrl, packages, require: dojoRequire } = loadDojoLoader(packageJson);
+
+		const nodeRequire = function (mid: string) {
+			// Require relative to the baseUrl, not this module.
+			return require(resolveFrom(baseUrl, mid));
+		};
+		Object.defineProperty(nodeRequire, 'resolve', {
+			configurable: false,
+			enumerable: true,
+			value (mid: string) {
+				return resolveFrom(baseUrl, mid);
+			}
+		});
+
+		grunt.log.ok(`Available packages: ${packages.map(({ name }) => name).join(', ')}`);
+		grunt.log.ok('require() is now powered by dojo-loader');
+		grunt.log.ok('Node.js\' require() is available under nodeRequire()');
+
+		const { context } = repl.start();
+		Object.defineProperties(context, {
+			nodeRequire: {
+				configurable: false,
+				enumerable: true,
+				value: nodeRequire
+			},
+			require: {
+				configurable: false,
+				enumerable: true,
+				value: dojoRequire
+			}
+		});
+	});
+};

--- a/tasks/run.ts
+++ b/tasks/run.ts
@@ -1,0 +1,13 @@
+import loadDojoLoader from '../lib/load-dojo-loader';
+
+export = function(grunt: IGrunt, packageJson: any) {
+	grunt.registerTask('run', 'Bootstrap dojo-loader and run the given --main', function () {
+		this.async(); // Ensure Grunt doesn't exit the process.
+
+		const main = grunt.option('main') || 'src/main';
+		grunt.log.ok(main);
+
+		const { require } = loadDojoLoader(packageJson);
+		require([main]);
+	});
+};


### PR DESCRIPTION
Once installed, `grunt run` will run the given `--main` after bootstrapping `dojo-loader`. Similarly `grunt repl` will start a REPL with `require()` set to `dojo-loader` and `nodeRequire()` giving access to Node's loader.

Packages are bootstrapped based on the `peerDependencies` with automatic mapping for common packages.