### PR TITLE
Convert to TS2.0 and support 'paths' and 'baseUrl' properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.js
 lcov.info
 !/tests/**/*.js
+.tsConfig*.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "4.1"
+  - "6.1"
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "6.1"
+  - "6"
 cache:
   directories:
     - node_modules

--- a/index.ts
+++ b/index.ts
@@ -4,15 +4,17 @@ import * as glob from 'glob';
 exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	const tsconfigContent = grunt.file.read('tsconfig.json');
 	const tsconfig = JSON.parse(tsconfigContent);
-	tsconfig.filesGlob = tsconfig.filesGlob.map(function (glob: string) {
-		if (/^\.\//.test(glob)) {
-			// Remove the leading './' from the glob because grunt-ts
-			// sees it and thinks it needs to create a .baseDir.ts which
-			// messes up the "dist" compilation
-			return glob.slice(2);
-		}
-		return glob;
-	});
+	if (tsconfig.filesGlob) {
+		tsconfig.filesGlob = tsconfig.filesGlob.map(function (glob: string) {
+			if (/^\.\//.test(glob)) {
+				// Remove the leading './' from the glob because grunt-ts
+				// sees it and thinks it needs to create a .baseDir.ts which
+				// messes up the "dist" compilation
+				return glob.slice(2);
+			}
+			return glob;
+		});
+	}
 	const packageJson = grunt.file.readJSON('package.json');
 
 	const devTasks = [
@@ -44,6 +46,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		tsconfigContent: tsconfigContent,
 		all: [ '<%= tsconfig.filesGlob %>' ],
 		skipTests: [ '<%= all %>' , '!tests/**/*.ts' ],
+		testsGlob: ['./tests/**/*.ts', 'tests/**/*.ts'],
 		staticTestFiles: 'tests/**/*.{html,css,json,xml,js,txt}',
 		staticDefinitionFiles: '**/*.d.ts',
 		devDirectory: '<%= tsconfig.compilerOptions.outDir %>',

--- a/options/ts.ts
+++ b/options/ts.ts
@@ -62,10 +62,7 @@ function getTsOptions(baseOptions: GruntTSOptions, overrides: GruntTSOptions) {
 	return options;
 }
 
-export = function (grunt: IGrunt) {
-	grunt.loadNpmTasks('grunt-ts');
-
-	const compilerOptions = grunt.config.get<any>('tsconfig').compilerOptions;
+function getTsTaskOptionsLegacy(compilerOptions: any): any {
 	const tsOptions = getTsOptions(compilerOptions, {
 		failOnTypeErrors: true,
 		fast: 'never'
@@ -104,4 +101,77 @@ export = function (grunt: IGrunt) {
 			src: [ '<%= skipTests %>' ]
 		}
 	};
+}
+
+function getTsTaskOptions(grunt: IGrunt, tsconfig: any): any {
+	const writeOptions = {
+		encoding: 'UTF8'
+	};
+	const distDir = grunt.config.get<any>('distDirectory');
+	const skipTests = grunt.config.get<string[]>('testsGlob');
+	const includeGlob: string[] = tsconfig.include || [];
+
+	const tsconfigDist = Object.assign({}, tsconfig, {
+		include: includeGlob.filter((item: string) => skipTests.indexOf(item) === -1)
+	});
+	Object.assign(tsconfigDist.compilerOptions, {
+		outDir: distDir,
+		declaration: true
+	});
+
+	const tsconfigDistEsm = Object.assign({}, tsconfig, {
+		include: includeGlob.filter((item: string) => skipTests.indexOf(item) === -1)
+	});
+	Object.assign(tsconfigDistEsm.compilerOptions, {
+		target: 'es6',
+		module: 'es6',
+		sourceMap: false,
+		outDir: 'dist/esm',
+		inlineSourceMap: true,
+		inlineSources: true
+	});
+
+	grunt.file.write('.tsconfigDist.json', JSON.stringify(tsconfigDist), writeOptions);
+	grunt.file.write('.tsconfigEsm.json', JSON.stringify(tsconfigDistEsm), writeOptions);
+
+	return {
+		options: {
+			failOnTypeErrors: true,
+			fast: 'never'
+		},
+		dev: {
+			tsconfig: {
+				passThrough: true
+			}
+		},
+		dist: {
+			tsconfig: {
+				tsconfig: '.tsconfigDist.json',
+				passThrough: true
+			}
+		},
+		dts: {
+			tsconfig: {
+				tsconfig: '.tsconfigDist.json',
+				passThrough: true
+			}
+		},
+		dist_esm: {
+			tsconfig: {
+				tsconfig: '.tsconfigEsm.json',
+				passThrough: true
+			}
+		}
+	};
+}
+
+export = function (grunt: IGrunt) {
+	grunt.loadNpmTasks('grunt-ts');
+
+	const tsconfig = grunt.config.get<any>('tsconfig');
+	if (tsconfig.compilerOptions.paths) {
+		return getTsTaskOptions(grunt, tsconfig);
+	}
+
+	return getTsTaskOptionsLegacy(tsconfig.compilerOptions);
 };

--- a/options/ts.ts
+++ b/options/ts.ts
@@ -76,6 +76,7 @@ function getTsTaskOptionsLegacy(compilerOptions: any): any {
 		dist: {
 			options: getTsOptions(tsOptions, {
 				mapRoot: '../dist/umd/_debug',
+				declaration: true,
 				sourceMap: true,
 				inlineSources: true
 			}),

--- a/package.json
+++ b/package.json
@@ -29,20 +29,18 @@
   "license": "BSD-3-Clause",
   "typings": "index.d.ts",
   "dependencies": {
-    "glob": "^7.0.0",
-    "grunt-typings": ">=0.1.5",
-    "resolve-from": "^2.0.0"
-  },
-  "peerDependencies": {
     "codecov.io": ">=0.1.6",
     "dts-generator": ">=1.7.0",
+    "glob": "^7.0.0",
     "grunt-contrib-clean": ">=1.0.0",
     "grunt-contrib-copy": ">=1.0.0",
     "grunt-contrib-watch": ">=1.0.0",
     "grunt-text-replace": ">=0.4.0",
     "grunt-ts": ">=5.0.0",
     "grunt-tslint": ">=3.0.0",
-    "remap-istanbul": ">=0.6.3"
+    "grunt-typings": "^0.1.5",
+    "remap-istanbul": ">=0.6.3",
+    "resolve-from": "^2.0.0"
   },
   "devDependencies": {
     "codecov.io": "0.1.6",
@@ -50,7 +48,7 @@
     "intern": "^3.2.0",
     "shx": ">=0.1.2",
     "tslint": "^3.10.1",
-    "typescript": "^1.8.10",
+    "typescript": "beta",
     "typings": "^1.3.1"
   }
 }

--- a/tasks/updateTsconfig.ts
+++ b/tasks/updateTsconfig.ts
@@ -2,12 +2,14 @@ export = function (grunt: IGrunt) {
 	grunt.registerTask('updateTsconfig', <any> function () {
 		var tsconfigContent = grunt.config.get<any>('tsconfigContent');
 		var tsconfig = JSON.parse(tsconfigContent);
-		tsconfig.files = grunt.file.expand(tsconfig.filesGlob);
+		if (tsconfig.filesGlob) {
+			tsconfig.files = grunt.file.expand(tsconfig.filesGlob);
 
-		var output = JSON.stringify(tsconfig, null, '\t') + require('os').EOL;
-		if (output !== tsconfigContent) {
-			grunt.file.write('tsconfig.json', output);
-			grunt.config.set('tsconfigContent', output);
+			var output = JSON.stringify(tsconfig, null, '\t') + require('os').EOL;
+			if (output !== tsconfigContent) {
+				grunt.file.write('tsconfig.json', output);
+				grunt.config.set('tsconfigContent', output);
+			}
 		}
 	});
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
 		"module": "commonjs",
 		"noImplicitAny": true,
 		"pretty": true,
-		"target": "es5"
+		"target": "es6"
 	},
 	"filesGlob": [
 		"./index.ts",

--- a/typings.json
+++ b/typings.json
@@ -8,8 +8,8 @@
 		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#8068ca9e347fa7a20963d8f9d6c8a05e380e2b1c",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#92fcf688c0982c1107fca278de52e4bfe23bd8af",
 		"gruntjs": "registry:dt/gruntjs#0.4.0+20160316171810",
+		"intern": "github:dojo/typings/custom/intern/intern.d.ts#92fcf688c0982c1107fca278de52e4bfe23bd8af",
 		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"nashorn": "github:dojo/typings/custom/nashorn/nashorn.d.ts#19d40cae45320285bea5aad1a40dedaf22eea648"
 	},
@@ -17,6 +17,6 @@
 		"glob": "registry:npm/glob#6.0.0+20160211003958"
 	},
 	"globalDevDependencies": {
-		"node": "registry:dt/node#4.0.0+20160509154515"
+		"node": "registry:dt/node#6.0.0+20160802155038"
 	}
 }


### PR DESCRIPTION
Converted to TS2.0 and target ES6.

Add support for `paths`/`baseUrl` compile properties supported from TS2.0 onwards, currently the only way to support these properties is by using `tsc` with a `tsconfig.json` not command line arguments (`error TS6064: Option 'paths' can only be specified in 'tsconfig.json' file.`).

To do this each of the `grunt-ts` targets has a customised `tsconfig.json` created at runtime based on the projects `tsconfig.json` using the convention `.tsconfig*.json` replacing `*` with a meaningful description i.e. `.tsconfigDist.json`.

The changes are backwards compatible so that any existing consumers will continue to leverage the `grunt-ts` tasks as previously configured and the new task configuration will only be used if `paths` is detected in the `compilerOptions` section of the `tsconfig`.

Consumers of the new tasks will need to add `.tsconfig*.json` to the projects `.gitignore` file.

resolves #10 