### PR TITLE
use 'include' for TS2.0

### DIFF
--- a/tasks/run.ts
+++ b/tasks/run.ts
@@ -4,7 +4,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 	grunt.registerTask('run', 'Bootstrap dojo-loader and run the given --main', function () {
 		this.async(); // Ensure Grunt doesn't exit the process.
 
-		const main = grunt.option('main') || 'src/main';
+		const main = <string> grunt.option('main') || 'src/main';
 		grunt.log.ok(main);
 
 		const { require } = loadDojoLoader(packageJson);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,31 +8,11 @@
 		"pretty": true,
 		"target": "es6"
 	},
-	"filesGlob": [
+	"include": [
 		"./index.ts",
 		"./index.d.ts",
 		"./options/**/*.ts",
 		"./tasks/**/*.ts",
-		"./typings/index.d.ts"
-	],
-	"files": [
-		"./index.ts",
-		"./index.d.ts",
-		"./options/clean.ts",
-		"./options/copy.ts",
-		"./options/dtsGenerator.ts",
-		"./options/intern.ts",
-		"./options/remapIstanbul.ts",
-		"./options/rename.ts",
-		"./options/replace.ts",
-		"./options/ts.ts",
-		"./options/tslint.ts",
-		"./options/typings.ts",
-		"./options/watch.ts",
-		"./tasks/rename.ts",
-		"./tasks/updateTsconfig.ts",
-		"./tasks/uploadCoverage.ts",
-		"./tasks/installPeerDependencies.ts",
 		"./typings/index.d.ts"
 	]
 }


### PR DESCRIPTION
Fixes: https://github.com/dojo/grunt-dojo2/issues/13

No longer need `files` and `filesGlob` needs to be renamed `include` for TS2.0.

