### PR TITLE
Feature configurable compile targets

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -58,7 +58,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		staticDefinitionFiles: '**/*.d.ts',
 		devDirectory: '<%= tsconfig.compilerOptions.outDir %>',
 		distDirectory: 'dist/umd/',
-
+		otherOptions: otherOptions,
 		devTasks,
 		distTasks,
 		distESMTasks

--- a/options/ts.ts
+++ b/options/ts.ts
@@ -143,14 +143,14 @@ function getTsTaskOptions(grunt: IGrunt, tsconfig: any): any {
 	Object.keys(tsOverrides).forEach((target) => {
 		if (target !== 'dist' && target !== 'esm' && target !== 'dev') {
 			const customTarget = tsOverrides[target];
-			const customTargetInclude: { include?: string[] } = {};
+			const customTargetOptions: { include?: string[], exclude?: string[] } = {};
 			if (customTarget.include) {
-				customTargetInclude.include = customTarget.include;
+				customTargetOptions.include = customTarget.include;
 			}
-			else if (customTarget.filterInclude) {
-				customTargetInclude.include = includeGlob.filter((item: string) => customTarget.filterInclude.indexOf(item) === -1);
+			if (customTarget.exclude) {
+				customTargetOptions.exclude = customTarget.exclude;
 			}
-			const customTsconfig = Object.assign({}, tsconfig, customTargetInclude);
+			const customTsconfig = Object.assign({}, tsconfig, customTargetOptions);
 			const customCompilerOptions = customTarget.compilerOptions ? customTarget.compilerOptions : {};
 
 			customTsconfig.compilerOptions = Object.assign({}, tsconfig.compilerOptions, customCompilerOptions);

--- a/options/ts.ts
+++ b/options/ts.ts
@@ -155,7 +155,7 @@ function getTsTaskOptions(grunt: IGrunt, tsconfig: any): any {
 
 			customTsconfig.compilerOptions = Object.assign({}, tsconfig.compilerOptions, customCompilerOptions);
 
-			grunt.file.write('.tsconfig' + target + '.json', JSON.stringify(tsconfigDistEsm), writeOptions);
+			grunt.file.write('.tsconfig' + target + '.json', JSON.stringify(customTsconfig), writeOptions);
 			customTargets[target] = {
 				tsconfig: {
 					tsconfig: '.tsconfig' + target + '.json',

--- a/options/ts.ts
+++ b/options/ts.ts
@@ -110,6 +110,9 @@ function getTsTaskOptions(grunt: IGrunt, tsconfig: any): any {
 	};
 	const distDir = grunt.config.get<any>('distDirectory');
 	const skipTests = grunt.config.get<string[]>('testsGlob');
+	const otherOptions = grunt.config.get<any>('otherOptions');
+	const tsOverrides = otherOptions.ts ? otherOptions.ts : {};
+
 	const includeGlob: string[] = tsconfig.include || [];
 
 	const tsconfigDist = Object.assign({}, tsconfig, {
@@ -118,7 +121,7 @@ function getTsTaskOptions(grunt: IGrunt, tsconfig: any): any {
 	tsconfigDist.compilerOptions = Object.assign({}, tsconfig.compilerOptions, {
 		outDir: distDir,
 		declaration: true
-	});
+	}, tsOverrides.dist);
 
 	const tsconfigDistEsm = Object.assign({}, tsconfig, {
 		include: includeGlob.filter((item: string) => skipTests.indexOf(item) === -1)
@@ -130,12 +133,39 @@ function getTsTaskOptions(grunt: IGrunt, tsconfig: any): any {
 		outDir: 'dist/esm',
 		inlineSourceMap: true,
 		inlineSources: true
-	});
+	}, tsOverrides.esm);
 
 	grunt.file.write('.tsconfigDist.json', JSON.stringify(tsconfigDist), writeOptions);
 	grunt.file.write('.tsconfigEsm.json', JSON.stringify(tsconfigDistEsm), writeOptions);
 
-	return {
+	const customTargets: any = {};
+
+	Object.keys(tsOverrides).forEach((target) => {
+		if (target !== 'dist' && target !== 'esm' && target !== 'dev') {
+			const customTarget = tsOverrides[target];
+			const customTargetInclude: { include?: string[] } = {};
+			if (customTarget.include) {
+				customTargetInclude.include = customTarget.include;
+			}
+			else if (customTarget.filterInclude) {
+				customTargetInclude.include = includeGlob.filter((item: string) => customTarget.filterInclude.indexOf(item) === -1);
+			}
+			const customTsconfig = Object.assign({}, tsconfig, customTargetInclude);
+			const customCompilerOptions = customTarget.compilerOptions ? customTarget.compilerOptions : {};
+
+			customTsconfig.compilerOptions = Object.assign({}, tsconfig.compilerOptions, customCompilerOptions);
+
+			grunt.file.write('.tsconfig' + target + '.json', JSON.stringify(tsconfigDistEsm), writeOptions);
+			customTargets[target] = {
+				tsconfig: {
+					tsconfig: '.tsconfig' + target + '.json',
+					passThrough: true
+				}
+			};
+		}
+	});
+
+	return Object.assign({
 		options: {
 			failOnTypeErrors: true,
 			fast: 'never'
@@ -163,7 +193,7 @@ function getTsTaskOptions(grunt: IGrunt, tsconfig: any): any {
 				passThrough: true
 			}
 		}
-	};
+	}, customTargets);
 }
 
 export = function (grunt: IGrunt) {


### PR DESCRIPTION
Allow overriding preset compilation targets attributes and configure custom targets.

`include` - completely overrides the `include` from the projects `tsconfig.json`.
`filterInclude` - filters the specified globs from the `tsconfig.json`'s `include`.
`compilerOptions` - overrides / sets the compiler options for the target

```json
"ts": {
	"custom1": {
		"include": [
			"src/**/*.ts",
			"test/**/*.ts"
		],
		"compilerOptions": {
			"declaration": true
		}
	},
	"custom2": {
		"include": [
			"test/**/*.ts"
		],
		"exclude": [
			"exclude/this/glob"
		],
		"compilerOptions": {
			"declaration": true
		}
	},
	"dist": {
		"exclude": [
			"exclude/this/glob"
		],
		"compilerOptions": {
			"declaration": false
		}
	}
}
```

resolves #18 