### PR TITLE
Add release task

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -77,6 +77,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	require('./tasks/installPeerDependencies')(grunt, packageJson);
 	require('./tasks/repl')(grunt, packageJson);
 	require('./tasks/run')(grunt, packageJson);
+	require('./tasks/release')(grunt, packageJson);
 
 	if (otherOptions) {
 		grunt.config.merge(otherOptions);

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "codecov.io": "0.1.6",
+    "execa": "^0.4.0",
     "grunt": "^1.0.1",
     "intern": "^3.2.0",
     "shx": ">=0.1.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "grunt-ts": ">=5.0.0",
     "grunt-tslint": ">=3.0.0",
     "grunt-typings": "^0.1.5",
+    "pkg-dir": "^1.0.0",
     "remap-istanbul": ">=0.6.3",
     "resolve-from": "^2.0.0"
   },

--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -53,7 +53,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 		}
 
 		bin = `${bin} ${args.join(' ')}`;
-		grunt.log.ok(bin);
+		grunt.log.ok(`${bin} - ${JSON.stringify(options)}`);
 
 		if (!dryRun || executeOnDryRun) {
 			return execa.shell(bin, options);
@@ -101,15 +101,15 @@ export = function(grunt: IGrunt, packageJson: any) {
 	grunt.registerTask('release-publish', 'publish the package to npm', function () {
 		const done = this.async();
 		const args = ['publish', '.'];
+		const promises = [command(npmBin, args, { cwd: temp }, false)];
 		if (tag) {
 			args.push('--tag', tag);
 		}
 		grunt.log.subhead('publishing to npm...');
 		if (dryRun) {
-			command(npmBin, ['pack', temp], {}, true).then(done);
-		} else {
-			command(npmBin, args, { cwd: temp }, false).then(done);
+			promises.push(command(npmBin, ['pack', '../' + temp], { cwd: 'dist' }, true));
 		}
+		Promise.all(promises).then(done);
 	});
 
 	grunt.registerTask('release-version-pre-release-tag', 'auto version based on pre release tag', function () {

--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -144,13 +144,16 @@ export = function(grunt: IGrunt, packageJson: any) {
 	});
 
 	grunt.registerTask('post-release-version', 'update the version post release', function () {
+		const done = this.async();
 		const packageJson = Object.assign({}, initialPackageJson);
 		if (nextVersion) {
 			packageJson.version = nextVersion;
 		}
 		grunt.file.write('package.json', JSON.stringify(packageJson, null, '  ') + '\n');
 		grunt.log.subhead(`version of package.json to commit: ${packageJson.version}`);
-		command(gitBin, ['commit', '-am', commitMsg], false);
+		command(gitBin, ['commit', '-am', commitMsg], false)
+			.then(() => grunt.log.subhead('release completed, remember to push back to remote'))
+			.then(done);
 	});
 
 	grunt.registerTask('release-publish-flat', 'publish the flat package', function () {

--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -15,7 +15,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 	const dryRun = grunt.option<boolean>('dry-run');
 	const tag = grunt.option<string>('tag');
 
-	const initialPackageJson = grunt.file.readJSON(process.cwd() + '/package.json');
+	const initialPackageJson = grunt.file.readJSON(path.join(packagePath, 'package.json'));
 	const commitMsg = '"Update package metadata"';
 
 	function matchesPreReleaseTag(preReleaseTag: string, version: string): string[] {
@@ -78,6 +78,17 @@ export = function(grunt: IGrunt, packageJson: any) {
 				grunt.fail.fatal(`cannot publish this package with user ${user}`);
 			}
 		}).then(done);
+	});
+
+	grunt.registerTask('repo-is-clean-check', 'check whether the repo is clean', function () {
+		const done = this.async();
+		command(gitBin, ['status', '--porcelain'], {}, true)
+			.then((result: any) => {
+				if (result.stdout) {
+					grunt.fail.fatal('repo is not clean');
+				}
+			})
+			.then(done);
 	});
 
 	grunt.registerTask('release-publish', 'publish the package to npm', function () {
@@ -151,7 +162,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 	});
 
 	grunt.registerTask('release', 'release', function () {
-		const tasks = ['dist'];
+		const tasks = ['repo-is-clean-check', 'dist'];
 		if (!dryRun) {
 			tasks.unshift('can-publish-check');
 		}

--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -7,6 +7,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 	const npmBin = 'npm';
 	const gitBin = 'git';
 	const temp = 'temp/';
+	const defaultBranch = 'master';
 	const preReleaseTags = ['alpha', 'beta', 'rc'];
 
 	const releaseVersion = grunt.option<string>('release-version');
@@ -85,7 +86,13 @@ export = function(grunt: IGrunt, packageJson: any) {
 		command(gitBin, ['status', '--porcelain'], {}, true)
 			.then((result: any) => {
 				if (result.stdout) {
-					grunt.fail.fatal('repo is not clean');
+					grunt.fail.fatal('there are changes in the working tree');
+				}
+			})
+			.then(() => command(gitBin, ['rev-parse', '--abbrev-ref', 'HEAD'], {}, true))
+			.then((result: any) => {
+				if (result.stdout !== defaultBranch) {
+					grunt.fail.fatal(`not on ${defaultBranch} branch`);
 				}
 			})
 			.then(done);

--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -1,0 +1,144 @@
+export = function(grunt: IGrunt, packageJson: any) {
+	const execa = require('execa');
+	const npmBin = 'npm';
+	const gitBin = 'git';
+	const temp = 'temp/';
+	const preReleaseTags = ['alpha', 'beta', 'rc'];
+
+	const releaseVersion = grunt.option<string>('release-version');
+	const nextVersion = grunt.option<string>('next-version');
+	const preReleaseTag = grunt.option<string>('pre-release-tag');
+	const dryRun = grunt.option<boolean>('dry-run');
+	const tag = grunt.option<string>('tag');
+
+	const initialPackageJson = grunt.file.readJSON(process.cwd() + '/package.json');
+	const commitMsg = '"Update package metadata"';
+
+	function matchesPreReleaseTag(preReleaseTag: string, version: string): string[] {
+		const regexp = new RegExp(`(.*)-(${preReleaseTag})\\.(\\d+)`);
+		return regexp.exec(version);
+	}
+
+	function matchesVersion(version1: string, version2: string): boolean {
+		return version2.indexOf(version1) === 0;
+	}
+
+	function getNextPreReleaseTagVersion(versionInPackage: string, existingVersions: string[]): string {
+		const filteredVersions = existingVersions
+			.filter((v) => matchesVersion(versionInPackage, v))
+			.filter((v) => matchesPreReleaseTag(preReleaseTag, v))
+			.map((v) => parseInt(matchesPreReleaseTag(preReleaseTag, v)[3], 10));
+
+		const nextVersion = filteredVersions.length ? Math.max(...filteredVersions) + 1 : 1;
+		return `${versionInPackage}-${preReleaseTag}.${nextVersion}`;
+	}
+
+	function preparePackageJson(packageJson: any): any {
+		packageJson.private = undefined;
+		packageJson.scripts = undefined;
+		packageJson.files = undefined;
+		packageJson.typings = undefined;
+		packageJson.main = 'main.js';
+		return packageJson;
+	}
+
+	function command(path: string, args: string[], options: any, executeOnDryRun?: boolean): Promise<any> {
+		if (dryRun && !executeOnDryRun) {
+			grunt.log.subhead('dry-run (not running)');
+		}
+		grunt.log.ok(`path: ${path}`);
+		grunt.log.ok(`args: ${args}`);
+		grunt.log.ok(`options: ${JSON.stringify(options)}`);
+
+		path = `${path} ${args.join(' ')}`;
+
+		if (!dryRun || executeOnDryRun) {
+			return execa.shell(path, args, options);
+		}
+		return Promise.resolve({});
+	}
+
+	grunt.registerTask('release-publish', 'publish the package to npm', function () {
+		const done = this.async();
+		const args = ['publish', '.'];
+		if (tag) {
+			args.push('--tag', tag);
+		}
+		grunt.log.subhead('publishing to npm...');
+		if (dryRun) {
+			command(npmBin, ['pack', temp], {}, true).then(done);
+		} else {
+			command(npmBin, args, { cwd: temp }, false).then(done);
+		}
+	});
+
+	grunt.registerTask('release-version-pre-release-tag', 'auto version based on pre release tag', function () {
+		const done = this.async();
+		const versionInPackage = initialPackageJson.version.replace(/-.*/g, '');
+		command(npmBin, ['view', '.', '--json'], {}, true).then((result: any) => {
+			if (result.stdout) {
+				const versions = <string[]> JSON.parse(result.stdout).versions;
+				const versionToRelease = getNextPreReleaseTagVersion(versionInPackage, versions);
+				const args = ['version', versionToRelease];
+
+				if (dryRun) {
+					args.unshift('--no-git-tag-version');
+				}
+
+				grunt.log.subhead(`version to release: ${versionToRelease}`);
+				return command(npmBin, args, {}, true).then(done);
+			} else {
+				grunt.fail.fatal('failed to fetch versions from npm');
+			}
+		});
+	});
+
+	grunt.registerTask('release-version-specific', 'set the version manually', function () {
+		const done = this.async();
+		const args = ['version', releaseVersion];
+		if (dryRun) {
+			args.unshift('--no-git-tag-version');
+		}
+		grunt.log.subhead(`version to release: ${releaseVersion}`);
+		command(npmBin, args, {}, true).then(done);
+	});
+
+	grunt.registerTask('post-release-version', 'update the version post release', function () {
+		const packageJson = Object.assign({}, initialPackageJson);
+		if (nextVersion) {
+			packageJson.version = nextVersion;
+		}
+		grunt.file.write('package.json', JSON.stringify(packageJson, null, '  '));
+		grunt.log.subhead(`version of package.json to commit: ${packageJson.version}`);
+		command(gitBin, ['commit', '-am', commitMsg], false);
+	});
+
+	grunt.registerTask('release-publish-flat', 'publish the flat package', function () {
+		grunt.log.subhead('making flat package...');
+		const pkg = grunt.file.readJSON(process.cwd() + '/package.json');
+		const dist = grunt.config('copy.staticDefinitionFiles.dest');
+		const tasks = ['copy:temp', 'release-publish', 'clean:temp'];
+
+		grunt.config.merge({
+			copy: { temp: { expand: true, cwd: dist, src: '**', dest: temp } },
+			clean: { temp: [ temp ] }
+		});
+
+		grunt.file.write(temp + 'package.json', JSON.stringify(preparePackageJson(pkg), null, '  '));
+		grunt.task.run(tasks);
+	});
+
+	grunt.registerTask('release', 'release', function () {
+		const tasks = ['dist'];
+		if (preReleaseTag && preReleaseTags.indexOf(preReleaseTag) > -1) {
+			tasks.push('release-version-pre-release-tag');
+		} else if (releaseVersion && nextVersion) {
+			tasks.push('release-version-specific');
+		} else {
+			grunt.fail.fatal('please specify --pre-release-tag or --release-version and --next-version');
+		}
+		tasks.push('release-publish-flat');
+		tasks.push('post-release-version');
+		grunt.task.run(tasks);
+	});
+};

--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -46,11 +46,9 @@ export = function(grunt: IGrunt, packageJson: any) {
 		if (dryRun && !executeOnDryRun) {
 			grunt.log.subhead('dry-run (not running)');
 		}
-		grunt.log.ok(`path: ${path}`);
-		grunt.log.ok(`args: ${args}`);
-		grunt.log.ok(`options: ${JSON.stringify(options)}`);
 
 		path = `${path} ${args.join(' ')}`;
+		grunt.log.ok(path);
 
 		if (!dryRun || executeOnDryRun) {
 			return execa.shell(path, args, options);


### PR DESCRIPTION
This attempts to automate away some of the `publishing` part of https://github.com/dojo/meta/blob/master/documents/Committer-Workflow.md

The task will:
* check that the branch is clean, and on the `master` branch
* check the user is both logged into npm, and has permissions to publish the package
* select the correct pre tag release version based on what is in the npm registry
* update the `package.json`, commit and tag
* prepare the package as a flat distribution
* publish to npm
* update the `package.json` version and commit

(it does **not** push back to the remote) 

for now, if wanting to bump the major, minor or patch on semver - you have to manually specify the `release-version` and `next-version` appropriately (this could be deduced in the future).

for pre release tags the version is set back to whatever pre version it was before automatically.

to release an alpha tag for example:
`grunt release --pre-release-tag=alpha`

to release a specific version: 
`grunt release --release-version=3.0.1 --next-version=3.0.2-pre`

you can specify an npm tag:
`grunt release --pre-release-tag=beta --tag=next`

to dry run:
`grunt release --pre-release-tag=alpha --dry-run`

`--dry-run` will modify the `package.json`, but not make any commits or tags, and rather than publishing to npm, it will pack it so you can inspect what the distribution would be.


