### PR TITLE
Add link task

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -77,6 +77,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	require('./tasks/repl')(grunt, packageJson);
 	require('./tasks/run')(grunt, packageJson);
 	require('./tasks/release')(grunt, packageJson);
+	require('./tasks/link')(grunt, packageJson);
 
 	if (otherOptions) {
 		grunt.config.merge(otherOptions);

--- a/options/clean.ts
+++ b/options/clean.ts
@@ -6,7 +6,10 @@ export = function (grunt: IGrunt) {
 			src: [ 'typings/' ]
 		},
 		dist: {
-			src: [ 'dist/' ]
+			src: [ 'dist/umd/*' ],
+			filter: function (path: string) {
+				return grunt.option('remove-links') ? true : !grunt.file.isLink(path);
+			}
 		},
 		dev: {
 			src: [ '<%= devDirectory %>' ]
@@ -15,7 +18,7 @@ export = function (grunt: IGrunt) {
 			src: [ '{src,tests}/**/*.js' ],
 			filter: function (path: string) {
 				// Only clean the .js file if a .js.map file also exists
-				var mapPath = path + '.map';
+				const mapPath = path + '.map';
 				if (grunt.file.exists(mapPath)) {
 					grunt.file.delete(mapPath);
 					return true;

--- a/tasks/link.ts
+++ b/tasks/link.ts
@@ -1,0 +1,40 @@
+export = function(grunt: IGrunt, packageJson: any) {
+	const execa = require('execa');
+	const fs = require('fs');
+	const path = require('path');
+	const process = require('process');
+	const pkgDir = require('pkg-dir');
+
+	grunt.registerTask('_link', '', function () {
+		const done = this.async();
+		const packagePath = pkgDir.sync(process.cwd());
+		const targetPath = grunt.config('distDirectory');
+
+		fs.symlink(
+			path.join(packagePath, 'node_modules'),
+			path.join(targetPath, 'node_modules'),
+			'junction',
+			() => {}
+		);
+		fs.symlink(
+			path.join(packagePath, 'package.json'),
+			path.join(targetPath, 'package.json'),
+			'file',
+			() => {}
+		);
+
+		execa.shell(`npm link ${targetPath}`)
+			.then((result: any) => grunt.log.ok(result.stdout))
+			.then(done);
+	});
+
+	grunt.registerTask('link', 'link', function () {
+		const targetPath = grunt.config('distDirectory');
+		const dirExists = grunt.file.isDir(targetPath);
+		const tasks = ['_link'];
+		if (!dirExists) {
+			tasks.unshift('dist');
+		}
+		grunt.task.run(tasks);
+	});
+};

--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -172,6 +172,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 	});
 
 	grunt.registerTask('release', 'release', function () {
+		grunt.option('remove-links', true);
 		const tasks = ['repo-is-clean-check', 'dist'];
 		if (!dryRun) {
 			tasks.unshift('can-publish-check');


### PR DESCRIPTION
Adds `grunt link`, which will setup the `dist/umd` directory to allow for `npm link {depName}` elsewhere.