### PR TITLE
Push back to git remote post release

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "codecov.io": ">=0.1.6",
     "dts-generator": ">=1.7.0",
+    "execa": "^0.4.0",
     "glob": "^7.0.0",
     "grunt-contrib-clean": ">=1.0.0",
     "grunt-contrib-copy": ">=1.0.0",
@@ -39,13 +40,13 @@
     "grunt-ts": ">=5.0.0",
     "grunt-tslint": ">=3.0.0",
     "grunt-typings": "^0.1.5",
+    "parse-git-config": "^0.4.2",
     "pkg-dir": "^1.0.0",
     "remap-istanbul": ">=0.6.3",
     "resolve-from": "^2.0.0"
   },
   "devDependencies": {
     "codecov.io": "0.1.6",
-    "execa": "^0.4.0",
     "grunt": "^1.0.1",
     "intern": "^3.2.0",
     "shx": ">=0.1.2",

--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -2,6 +2,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 	const execa = require('execa');
 	const path = require('path');
 	const pkgDir = require('pkg-dir');
+	const parse = require('parse-git-config');
 
 	const packagePath = pkgDir.sync(process.cwd());
 	const npmBin = 'npm';
@@ -9,6 +10,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 	const temp = 'temp/';
 	const defaultBranch = 'master';
 	const preReleaseTags = ['alpha', 'beta', 'rc'];
+	const gitBaseRemote = 'git@github.com:dojo/';
 
 	const releaseVersion = grunt.option<string>('release-version');
 	const nextVersion = grunt.option<string>('next-version');
@@ -45,6 +47,16 @@ export = function(grunt: IGrunt, packageJson: any) {
 		packageJson.typings = undefined;
 		packageJson.main = 'main.js';
 		return packageJson;
+	}
+
+	function getGitRemote(): string|boolean {
+		const gitConfig = parse.sync();
+		const remotes = Object.keys(gitConfig)
+			.filter((key) => key.indexOf('remote') === 0)
+			.filter((key) => gitConfig[key].url.indexOf(gitBaseRemote) === 0)
+			.map((key) => gitConfig[key].url);
+
+		return remotes.length ? remotes[0] : false;
 	}
 
 	function command(bin: string, args: string[], options: any, executeOnDryRun?: boolean): Promise<any> {
@@ -151,8 +163,18 @@ export = function(grunt: IGrunt, packageJson: any) {
 		}
 		grunt.file.write('package.json', JSON.stringify(packageJson, null, '  ') + '\n');
 		grunt.log.subhead(`version of package.json to commit: ${packageJson.version}`);
-		command(gitBin, ['commit', '-am', commitMsg], false)
-			.then(() => grunt.log.subhead('release completed, remember to push back to remote'))
+		command(gitBin, ['commit', '-am', commitMsg], {}, false)
+			.then(() => {
+				const remote = getGitRemote();
+				if (remote) {
+					return Promise.all([
+						command(gitBin, ['push', <string> remote, defaultBranch], {}, false),
+						command(gitBin, ['push', <string> remote, '--tags'], {}, false)
+					]);
+				} else {
+					grunt.log.subhead('release completed, but could not find remote to push back to. please manually push the changes.');
+				}
+			})
 			.then(done);
 	});
 

--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -17,6 +17,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 	const preReleaseTag = grunt.option<string>('pre-release-tag');
 	const dryRun = grunt.option<boolean>('dry-run');
 	const tag = grunt.option<string>('tag');
+	const pushBack = grunt.option<boolean>('push-back');
 
 	const initialPackageJson = grunt.file.readJSON(path.join(packagePath, 'package.json'));
 	const commitMsg = '"Update package metadata"';
@@ -165,6 +166,9 @@ export = function(grunt: IGrunt, packageJson: any) {
 		grunt.log.subhead(`version of package.json to commit: ${packageJson.version}`);
 		command(gitBin, ['commit', '-am', commitMsg], {}, false)
 			.then(() => {
+				if (!pushBack) {
+					return;
+				}
 				const remote = getGitRemote();
 				if (remote) {
 					return Promise.all([
@@ -172,9 +176,10 @@ export = function(grunt: IGrunt, packageJson: any) {
 						command(gitBin, ['push', <string> remote, '--tags'], {}, false)
 					]);
 				} else {
-					grunt.log.subhead('release completed, but could not find remote to push back to. please manually push the changes.');
+					grunt.log.subhead('could not find remote to push back to. please manually push the changes.');
 				}
 			})
+			.then(() => grunt.log.subhead('release completed'))
 			.then(done);
 	});
 


### PR DESCRIPTION
The release task will now look for a dojo remote in the .gitconfig, if it finds one it will try and push the commits and tags back to the remote.