### PR TITLE
Fix sourcemap sources for dist

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,7 +37,8 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		'typings',
 		'tslint',
 		'clean:dist',
-		'ts:dist'
+		'ts:dist',
+		'fixSourceMaps'
 	];
 
 	const distESMTasks = [
@@ -78,6 +79,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	require('./tasks/run')(grunt, packageJson);
 	require('./tasks/release')(grunt, packageJson);
 	require('./tasks/link')(grunt, packageJson);
+	require('./tasks/fixSourceMaps')(grunt, packageJson);
 
 	if (otherOptions) {
 		grunt.config.merge(otherOptions);

--- a/tasks/fixSourceMaps.ts
+++ b/tasks/fixSourceMaps.ts
@@ -1,0 +1,26 @@
+export = function (grunt: IGrunt) {
+
+	/**
+	 * When compiling with --inlineSources, tsc generates sources which include folder
+	 * paths. Until this is fixed, we need to remove paths leaving just the filename.
+	 *
+	 * ie '../../src/has.ts' -> 'has.ts'
+	 *
+	 * @param sourceMap input source map
+	 * @return modified source map
+	 */
+	function fixSources(sourceMap: any): any {
+		sourceMap.sources = sourceMap.sources.map((source: string) => source.replace(/.*\//, ''));
+		return sourceMap;
+	}
+
+	grunt.registerTask('fixSourceMaps', <any> function () {
+		const dist = grunt.config('distDirectory');
+		const fixers = [ fixSources ];
+		grunt.file.expand({ filter: 'isFile'}, [dist + '/**/*.js.map']).forEach(function(path) {
+			const inputSourceMap = grunt.file.readJSON(path);
+			const outputSourceMap = fixers.reduce((sourceMap, fixer) => fixer(sourceMap), inputSourceMap);
+			grunt.file.write(path, JSON.stringify(outputSourceMap));
+		});
+	});
+};


### PR DESCRIPTION
Fixes https://github.com/dojo/grunt-dojo2/issues/46

When compiling with `--inlineSources`, `tsc` generates `sources` which include folder
paths. You can set the `sourceRoot` in the compiler options which should fix this, but they resolve to absolute paths in ts 2.x
Until this is fixed, we need to remove paths leaving just the filename.

ie: `./../src/has.ts` -> `has.ts`