### PR TITLE
Copy README for release

### DIFF
--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -12,6 +12,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 	const preReleaseTags = ['alpha', 'beta', 'rc'];
 	const gitBaseRemote = 'git@github.com:dojo/';
 	const defaultMaintainers = ['sitepen', 'dojotoolkit'];
+	const extraToCopy = ['README.md'];
 
 	const releaseVersion = grunt.option<string>('release-version');
 	const nextVersion = grunt.option<string>('next-version');
@@ -209,6 +210,12 @@ export = function(grunt: IGrunt, packageJson: any) {
 		});
 
 		grunt.file.write(path.join(temp, 'package.json'), JSON.stringify(preparePackageJson(pkg), null, '  ') + '\n');
+
+		extraToCopy.forEach((fileName) => {
+			if (grunt.file.exists(fileName)) {
+				grunt.file.copy(fileName, temp + '/' + fileName);
+			}
+		});
 		grunt.task.run(tasks);
 	});
 


### PR DESCRIPTION
Fixes https://github.com/dojo/grunt-dojo2/issues/49
The release tool only copies the output from `dist`. Added support for copying additional files such as the README to be included in the package.