### PR TITLE
Use targetPath as cwd to run npm link

### DIFF
--- a/tasks/link.ts
+++ b/tasks/link.ts
@@ -23,7 +23,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 			() => {}
 		);
 
-		execa.shell(`npm link ${targetPath}`)
+		execa.shell('npm link', { cwd: targetPath })
 			.then((result: any) => grunt.log.ok(result.stdout))
 			.then(done);
 	});


### PR DESCRIPTION
Should fix the cyclical symlink when npm linking.