### PR TITLE
Fix maintainers check

### DIFF
--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -108,7 +108,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 		return Promise.all([whoamiPromise, maintainersPromise]).then((results) => {
 			const user = results[0];
 			const maintainers = results[1];
-			const isMaintainer = maintainers.indexOf(user) === 0;
+			const isMaintainer = maintainers.indexOf(user) > -1;
 			if (!isMaintainer) {
 				grunt.fail.fatal(`cannot publish this package with user ${user}`);
 			}


### PR DESCRIPTION
*Expected behaviour:*
Can publish to npm with a maintainer in the maintainer list

*Actual behaviour:*
Failed the npm maintainer check.

For some reason I was only checking against the first maintainer in the array.

We dearly need some tests for the grunt tasks: https://github.com/dojo/grunt-dojo2/issues/1
