### PR TITLE
POC: Support for releasing as ESM format

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -42,7 +42,12 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	];
 
 	const distESMTasks = [
-		'ts:esm'
+		'clean:typings',
+		'typings',
+		'tslint',
+		'clean:dist_esm',
+		'ts:esm',
+		'fixSourceMaps'
 	];
 
 	grunt.initConfig({

--- a/options/clean.ts
+++ b/options/clean.ts
@@ -11,6 +11,12 @@ export = function (grunt: IGrunt) {
 				return grunt.option('remove-links') ? true : !grunt.file.isLink(path);
 			}
 		},
+		dist_esm: {
+			src: [ 'dist/esm/*' ],
+			filter: function (path: string) {
+				return grunt.option('remove-links') ? true : !grunt.file.isLink(path);
+			}
+		},
 		dev: {
 			src: [ '<%= devDirectory %>' ]
 		},

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   "license": "BSD-3-Clause",
   "typings": "index.d.ts",
   "dependencies": {
+    "babel-core": "^6.17.0",
+    "babel-plugin-module-resolver": "^2.2.0",
     "codecov.io": ">=0.1.6",
     "dts-generator": ">=1.7.0",
     "execa": "^0.4.0",
@@ -40,9 +42,9 @@
     "grunt-ts": ">=5.0.0",
     "grunt-tslint": ">=3.0.0",
     "grunt-typings": "^0.1.5",
+    "lodash": "^4.15.0",
     "parse-git-config": "^0.4.2",
     "pkg-dir": "^1.0.0",
-    "lodash": "^4.15.0",
     "remap-istanbul": ">=0.6.3",
     "resolve-from": "^2.0.0"
   },

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -15,7 +15,7 @@ export = function(grunt: IGrunt) {
 		esm: {
 			exclude: ['tests/**/*.ts'],
 			compilerOptions: {
-				target: 'es6',
+				target: 'es5',
 				module: 'es6',
 				sourceMap: false,
 				outDir: 'dist/esm',

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -15,9 +15,10 @@ export = function(grunt: IGrunt) {
 		esm: {
 			exclude: ['tests/**/*.ts'],
 			compilerOptions: {
+				outDir: 'dist/esm',
+				declaration: true,
 				target: 'es5',
 				module: 'es6',
-				outDir: 'dist/esm',
 				sourceMap: true,
 				inlineSources: true
 			}

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -17,8 +17,8 @@ export = function(grunt: IGrunt) {
 			compilerOptions: {
 				target: 'es5',
 				module: 'es6',
-				sourceMap: false,
 				outDir: 'dist/esm',
+				sourceMap: true,
 				inlineSourceMap: true,
 				inlineSources: true
 			}

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -19,7 +19,6 @@ export = function(grunt: IGrunt) {
 				module: 'es6',
 				outDir: 'dist/esm',
 				sourceMap: true,
-				inlineSourceMap: true,
 				inlineSources: true
 			}
 		}


### PR DESCRIPTION
This basically adds support to the release task for ESM publishing (https://github.com/dojo/grunt-dojo2/issues/37). It first of all still down emits to ES5, but with ES modules. There is then a transform for rewriting dependencies of the source from the umd package name to the esm package name for example: 

```
import { assign } from 'dojo-core/lang';`
```

will be rewritten to:

```
import { assign } from 'dojo-core-esm/lang';
```

It also rewrites the `package.json` to switch the dependencies to the esm equivelants.

This should allow us to consume dojo 2 in Webpack 2 as ESM and take advantage of tree shaking.

The PR is blocked by:
https://github.com/dojo/grunt-dojo2/issues/64

And it contains a map of dependencies which should potentially in the future live in `dojo/meta` see https://github.com/dojo/meta/issues/76.
