### PR TITLE
Copy d.ts files for dist

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,6 +37,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		'typings',
 		'tslint',
 		'clean:dist',
+		'copy:staticDefinitionFiles',
 		'ts:dist',
 		'fixSourceMaps'
 	];


### PR DESCRIPTION
As tsc won't emit them. Simple fix as we already had a copy target setup to do this.

Fixes: https://github.com/dojo/grunt-dojo2/issues/63
