### PR TITLE
Renaming ts task because it conflicts with grunt-ts, issue #64

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -29,7 +29,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		'typings:dev',
 		'tslint',
 		'clean:dev',
-		'ts:dev',
+		'dojo-ts:dev',
 		'copy:staticTestFiles'
 	];
 
@@ -39,12 +39,12 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		'tslint',
 		'clean:dist',
 		'copy:staticDefinitionFiles',
-		'ts:dist',
+		'dojo-ts:dist',
 		'fixSourceMaps'
 	];
 
 	const distESMTasks = [
-		'ts:esm'
+		'dojo-ts:esm'
 	];
 
 	grunt.initConfig({

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -26,7 +26,7 @@ export = function(grunt: IGrunt) {
 		}
 	};
 
-	grunt.registerTask('ts', <any> function (this: ITask) {
+	grunt.registerTask('dojo-ts', <any> function (this: ITask) {
 		grunt.loadNpmTasks('grunt-ts');
 
 		const flags = this.args && this.args.length ? this.args : [ 'dev' ];

--- a/tests/unit/tasks/ts.ts
+++ b/tests/unit/tasks/ts.ts
@@ -60,7 +60,7 @@ registerSuite({
 	},
 
 	default() {
-		runGruntTask('ts');
+		runGruntTask('dojo-ts');
 
 		assert.deepEqual(grunt.config('ts.dev'), {
 			tsconfig: {
@@ -75,7 +75,7 @@ registerSuite({
 
 	dev() {
 
-		runGruntTask('ts:dev');
+		runGruntTask('dojo-ts:dev');
 
 		assert.deepEqual(grunt.config('ts.dev'), {
 			tsconfig: {
@@ -89,7 +89,7 @@ registerSuite({
 	},
 
 	dist() {
-		runGruntTask('ts:dist');
+		runGruntTask('dojo-ts:dist');
 
 		assert.deepEqual(grunt.config('ts.dist'), {
 			tsconfig: {
@@ -121,7 +121,7 @@ registerSuite({
 			}
 		});
 
-		runGruntTask('ts:esm');
+		runGruntTask('dojo-ts:esm');
 
 		assert.deepEqual(grunt.config('ts.esm'), {
 			tsconfig: {
@@ -138,7 +138,7 @@ registerSuite({
 	},
 
 	custom() {
-		runGruntTask('ts:custom');
+		runGruntTask('dojo-ts:custom');
 
 		assert.deepEqual(grunt.config('ts.custom'), {
 			tsconfig: {


### PR DESCRIPTION
Issue #64 

I renamed the `ts` task to be `dojo-ts`. After `grunt-ts` had been loaded once (by the first `ts:dist` command), the `ts` task was being overridden by `grunt-ts`, causing the 2nd command to fail.  The easiest solution seemed to just rename our command...