### PR TITLE
Support yarn for installing peer deps

### DIFF
--- a/tasks/installPeerDependencies.ts
+++ b/tasks/installPeerDependencies.ts
@@ -3,14 +3,23 @@ import { execSync as exec } from 'child_process';
 export = function(grunt: IGrunt, packageJson: any) {
 	grunt.registerTask('peerDepInstall', <any> function () {
 		const peerDeps = packageJson.peerDependencies;
+		let packageCmd = 'yarn add --ignore-engines';
+
+		try {
+			exec('yarn --version');
+		}
+		catch (error) {
+			packageCmd = 'npm install';
+		}
 
 		for (let name in peerDeps) {
 			grunt.log.write(`installing peer dependency ${name} with version ${peerDeps[name]}...`);
 			try {
-				let cmd = `npm install ${name}@"${peerDeps[name]}"`;
+				let cmd = `${packageCmd} ${name}@"${peerDeps[name]}"`;
 				exec(cmd, { stdio: 'ignore' });
 				grunt.log.ok('complete.');
 			} catch (error) {
+				grunt.log.verbose.error(error);
 				grunt.log.error('failed.');
 			}
 		}

--- a/tests/unit/tasks/installPeerDependencies.ts
+++ b/tests/unit/tasks/installPeerDependencies.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import * as grunt from 'grunt'
-import { SinonStub, stub } from "sinon";
+import * as grunt from 'grunt';
+import { SinonStub, stub } from 'sinon';
 import { loadTasks, unloadTasks, runGruntTask } from '../util';
 
 let mockLogger: SinonStub;
@@ -9,43 +9,72 @@ let mockShell: SinonStub;
 
 registerSuite({
 	name: 'tasks/installPeerDependencies',
-	setup() {
-		grunt.initConfig({});
-
-		mockLogger = stub(grunt.log, 'error');
-		mockShell = stub();
-
-		mockShell.withArgs(
-			'npm install my-dep@"1.0"'
-		).returns(
-			Promise.resolve({})
-		).withArgs(
-			'npm install error-dep@"1.0"'
-		).throws();
-
-		loadTasks({
-			child_process: {
-				execSync: mockShell
-			}
-		}, {
-			peerDependencies: {
-				'my-dep': '1.0',
-				'error-dep': '1.0'
-			}
-		});
-	},
-	teardown() {
+	afterEach() {
 		mockLogger.restore();
 		unloadTasks();
 	},
+	'npm': {
+		beforeEach() {
+			grunt.initConfig({});
+			mockLogger = stub(grunt.log, 'error');
+			mockShell = stub();
 
-	runsCommands() {
-		runGruntTask('peerDepInstall');
+			mockShell
+			.withArgs('yarn --version').throws()
+			.withArgs('npm install my-dep@"1.0"').returns(Promise.resolve({}))
+			.withArgs('npm install error-dep@"1.0"').throws();
 
-		assert.isTrue(mockShell.calledTwice);
-		assert.isTrue(mockShell.calledWith('npm install my-dep@"1.0"'));
-		assert.isTrue(mockShell.calledWith('npm install error-dep@"1.0"'));
-		assert.isTrue(mockLogger.called);
-		assert.isTrue(mockLogger.calledWith('failed.'));
+			loadTasks({
+				child_process: {
+					execSync: mockShell
+				}
+			}, {
+				peerDependencies: {
+					'my-dep': '1.0',
+					'error-dep': '1.0'
+				}
+			});
+		},
+		runsCommands() {
+			runGruntTask('peerDepInstall');
+
+			assert.isTrue(mockShell.calledThrice);
+			assert.isTrue(mockShell.calledWith('npm install my-dep@"1.0"'));
+			assert.isTrue(mockShell.calledWith('npm install error-dep@"1.0"'));
+			assert.isTrue(mockLogger.called);
+			assert.isTrue(mockLogger.calledWith('failed.'));
+		}
+	},
+	'yarn': {
+		beforeEach() {
+			grunt.initConfig({});
+			mockLogger = stub(grunt.log, 'error');
+			mockShell = stub();
+
+			mockShell
+			.withArgs('yarn --version').returns(Promise.resolve({}))
+			.withArgs('yarn add --ignore-engines my-dep@"1.0"').returns(Promise.resolve({}))
+			.withArgs('yarn add --ignore-engines error-dep@"1.0"').throws();
+
+			loadTasks({
+				child_process: {
+					execSync: mockShell
+				}
+			}, {
+				peerDependencies: {
+					'my-dep': '1.0',
+					'error-dep': '1.0'
+				}
+			});
+		},
+		runsCommands() {
+			runGruntTask('peerDepInstall');
+
+			assert.isTrue(mockShell.calledThrice);
+			assert.isTrue(mockShell.calledWith('yarn add --ignore-engines my-dep@"1.0"'));
+			assert.isTrue(mockShell.calledWith('yarn add --ignore-engines error-dep@"1.0"'));
+			assert.isTrue(mockLogger.called);
+			assert.isTrue(mockLogger.calledWith('failed.'));
+		}
 	}
 });


### PR DESCRIPTION
Check `yarn` availability prior to installing peer dependencies and use `yarn` over `npm` if found

Resolves #82 