### PR TITLE
Remove postcss from default tasks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -40,8 +40,6 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		'clean:dist',
 		'copy:staticDefinitionFiles',
 		'dojo-ts:dist',
-		'postcss:modules',
-		'postcss:variables',
 		'fixSourceMaps'
 	];
 


### PR DESCRIPTION
Removing the `postcss` tasks from the default tasks as they were causing problems with `cli-build-app` which has a `main.css` in it's templates directory.
The two required tasks can be added to the `dist` task in `widgets` where they are required instead.