### PR TITLE
Add postcss to dev stack

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		'typings:dev',
 		'tslint',
 		'clean:dev',
+		'copy:staticDefinitionFiles-dev',
 		'dojo-ts:dev',
 		'copy:staticTestFiles'
 	];
@@ -38,7 +39,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		'typings:dist',
 		'tslint',
 		'clean:dist',
-		'copy:staticDefinitionFiles',
+		'copy:staticDefinitionFiles-dist',
 		'dojo-ts:dist',
 		'fixSourceMaps'
 	];

--- a/options/copy.ts
+++ b/options/copy.ts
@@ -1,4 +1,6 @@
 export = function (grunt: IGrunt) {
+	const path = require('path');
+	
 	grunt.loadNpmTasks('grunt-contrib-copy');
 
 	return {
@@ -8,7 +10,13 @@ export = function (grunt: IGrunt) {
 			src: [ '<%= staticTestFiles %>' ],
 			dest: '<%= devDirectory %>'
 		},
-		staticDefinitionFiles: {
+		'staticDefinitionFiles-dev': {
+			expand: true,
+			cwd: '.',
+			src: [ path.join('src', '<%= staticDefinitionFiles %>') ],
+			dest: '<%= devDirectory %>'
+		},
+		'staticDefinitionFiles-dist': {
 			expand: true,
 			cwd: 'src',
 			src: [ '<%= staticDefinitionFiles %>' ],

--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -9,28 +9,33 @@ export = function(grunt: IGrunt) {
 	grunt.loadNpmTasks('grunt-postcss');
 
 	const distDirectory = grunt.config.get<string>('distDirectory');
+	const devDirectory = grunt.config.get<string>('devDirectory');
 
-	const moduleProcessors: any = [
-		postCssImport,
-		postCssNext({
-			features: {
-				autoprefixer: {
-					browsers: [
-						'last 2 versions',
-						'ie >= 10'
-					]
+	function moduleProcessors(dest: string, cwd = '') {
+		return [
+			postCssImport,
+			postCssNext({
+				features: {
+					autoprefixer: {
+						browsers: [
+							'last 2 versions',
+							'ie >= 10'
+						]
+					}
 				}
-			}
-		}),
-		postCssModules({
-			generateScopedName: '[hash:base64:8]',
-			getJSON: function(cssFileName: string, json: JSON) {
-				const outputPath = path.resolve(distDirectory, path.relative('src', cssFileName));
-				const newFilePath = outputPath.replace(/.css$/, '.js');
-				fs.writeFileSync(newFilePath, umdWrapper(JSON.stringify(json)));
-			}
-		})
-	];
+			}),
+			postCssModules({
+				generateScopedName: '[hash:base64:8]',
+				getJSON: function(cssFileName: string, json: JSON) {
+					console.log(dest);
+					console.log(path.relative('src', cssFileName));
+					const outputPath = path.resolve(dest, path.relative(cwd, cssFileName));
+					const newFilePath = outputPath.replace(/.css$/, '.js');
+					fs.writeFileSync(newFilePath, umdWrapper(JSON.stringify(json)));
+				}
+			})
+		];
+	}
 
 	const variablesProcessors: any = [
 		postCssImport,
@@ -43,33 +48,49 @@ export = function(grunt: IGrunt) {
 		})
 	];
 
-	const moduleFiles = [{
-		expand: true,
-		src: ['**/*.css', '!**/variables.css'],
-		exclude: '**/variables.css',
-		dest: distDirectory,
-		cwd: 'src'
-	}];
+	function moduleFiles(dest: string) {
+		return [{
+			expand: true,
+			src: ['**/*.css', '!**/variables.css'],
+			exclude: '**/variables.css',
+			dest: dest,
+			cwd: 'src'
+		}];
+	}
 
-	const variableFiles = [{
-		expand: true,
-		src: '**/variables.css',
-		dest: distDirectory,
-		cwd: 'src'
-	}];
+	function variableFiles(dest: string) {
+		return [{
+			expand: true,
+			src: '**/variables.css',
+			dest: dest,
+			cwd: 'src'
+		}];
+	}
 
 	grunt.config.set('postcss', {
 		options: {
 			map: true
 		},
-		modules: {
-			files: moduleFiles,
+		'modules-dev': {
+			files: moduleFiles(path.join(devDirectory, 'src')),
 			options: {
-				processors: moduleProcessors
+				processors: moduleProcessors(devDirectory)
 			}
 		},
-		variables: {
-			files: variableFiles,
+		'variables-dev': {
+			files: variableFiles(path.join(devDirectory, 'src')),
+			options: {
+				processors: variablesProcessors
+			}
+		},
+		'modules-dist': {
+			files: moduleFiles(distDirectory),
+			options: {
+				processors: moduleProcessors(distDirectory, 'src')
+			}
+		},
+		'variables-dist': {
+			files: variableFiles(distDirectory),
 			options: {
 				processors: variablesProcessors
 			}

--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -8,10 +8,11 @@ export = function(grunt: IGrunt) {
 
 	grunt.loadNpmTasks('grunt-postcss');
 
-	const distDirectory = grunt.config.get<string>('distDirectory');
-	const devDirectory = grunt.config.get<string>('devDirectory');
+	const distDirectory = grunt.config.get<string>('distDirectory') || '';
+	const devDirectory = grunt.config.get<string>('devDirectory') || '';
 
 	function moduleProcessors(dest: string, cwd = '') {
+		const scopedName = dest === devDirectory ? '[name]__[local]__[hash:base64:5]' : '[hash:base64:8]';
 		return [
 			postCssImport,
 			postCssNext({
@@ -25,7 +26,7 @@ export = function(grunt: IGrunt) {
 				}
 			}),
 			postCssModules({
-				generateScopedName: '[hash:base64:8]',
+				generateScopedName: scopedName,
 				getJSON: function(cssFileName: string, json: JSON) {
 					const outputPath = path.resolve(dest, path.relative(cwd, cssFileName));
 					const newFilePath = outputPath.replace(/.css$/, '.js');

--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -27,8 +27,6 @@ export = function(grunt: IGrunt) {
 			postCssModules({
 				generateScopedName: '[hash:base64:8]',
 				getJSON: function(cssFileName: string, json: JSON) {
-					console.log(dest);
-					console.log(path.relative('src', cssFileName));
 					const outputPath = path.resolve(dest, path.relative(cwd, cssFileName));
 					const newFilePath = outputPath.replace(/.css$/, '.js');
 					fs.writeFileSync(newFilePath, umdWrapper(JSON.stringify(json)));

--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -57,14 +57,12 @@ export = function(grunt: IGrunt) {
 		}];
 	}
 
-	function variableFiles(dest: string) {
-		return [{
-			expand: true,
-			src: '**/variables.css',
-			dest: dest,
-			cwd: 'src'
-		}];
-	}
+	const variableFiles = [{
+		expand: true,
+		src: '**/variables.css',
+		dest: distDirectory,
+		cwd: 'src'
+	}];
 
 	grunt.config.set('postcss', {
 		options: {
@@ -76,20 +74,14 @@ export = function(grunt: IGrunt) {
 				processors: moduleProcessors(devDirectory)
 			}
 		},
-		'variables-dev': {
-			files: variableFiles(path.join(devDirectory, 'src')),
-			options: {
-				processors: variablesProcessors
-			}
-		},
 		'modules-dist': {
 			files: moduleFiles(distDirectory),
 			options: {
 				processors: moduleProcessors(distDirectory, 'src')
 			}
 		},
-		'variables-dist': {
-			files: variableFiles(distDirectory),
+		variables: {
+			files: variableFiles,
 			options: {
 				processors: variablesProcessors
 			}

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -5,7 +5,7 @@ export = function(grunt: IGrunt) {
 	const distDirectory = grunt.config.get<string>('distDirectory');
 	const defaultOptions: any = {
 		dist: {
-			exclude: ['tests/**/*.ts'],
+			exclude: ['tests/**/*.ts', 'src/examples/**/*.ts'],
 			compilerOptions: {
 				outDir: distDirectory,
 				declaration: true,


### PR DESCRIPTION
This would look a little nicer if we could combine the module and variable task configurations. It at least works and can serve as a basis to iterate on. We're at a point where we need this in order to submit widget PRs.

Resolves #87 