### PR TITLE
Add path and classes to css-modules json to assist a theme hierarchy

### DIFF
--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -30,7 +30,11 @@ export = function(grunt: IGrunt) {
 				getJSON: function(cssFileName: string, json: JSON) {
 					const outputPath = path.resolve(dest, path.relative(cwd, cssFileName));
 					const newFilePath = outputPath.replace(/.css$/, '.js');
-					fs.writeFileSync(newFilePath, umdWrapper(JSON.stringify(json)));
+					const output = {
+						classes: json,
+						path: path.basename(outputPath, '.css')
+					};
+					fs.writeFileSync(newFilePath, umdWrapper(JSON.stringify(output)));
 				}
 			})
 		];

--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -33,7 +33,7 @@ export = function(grunt: IGrunt) {
 					const output = {
 						default: {
 							classes: json,
-							path: path.basename(outputPath, '.css')
+							key: 'dojo-' + path.basename(outputPath, '.css')
 						}
 					};
 					fs.writeFileSync(newFilePath, umdWrapper(JSON.stringify(output)));

--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -31,8 +31,10 @@ export = function(grunt: IGrunt) {
 					const outputPath = path.resolve(dest, path.relative(cwd, cssFileName));
 					const newFilePath = outputPath.replace(/.css$/, '.js');
 					const output = {
-						classes: json,
-						path: path.basename(outputPath, '.css')
+						default: {
+							classes: json,
+							path: path.basename(outputPath, '.css')
+						}
 					};
 					fs.writeFileSync(newFilePath, umdWrapper(JSON.stringify(output)));
 				}


### PR DESCRIPTION
**Type:** Feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide]

**Description:**

Changes grunt-dojo2 to create a more complex css-module output including path and classes data.

**Depends Upon**

* [ ] widget core pr: https://github.com/dojo/widget-core/pull/301
* [ ] cli-build pr: https://github.com/dojo/cli-build/pull/57

Resolves https://github.com/dojo/widget-core/issues/296
