### PR TITLE
Add typedoc task

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -48,6 +48,12 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		'dojo-ts:esm'
 	];
 
+	const docTasks = [
+		'clean:typings',
+		'typings:dev',
+		'typedoc'
+	];
+
 	grunt.initConfig({
 		name: packageJson.name,
 		version: packageJson.version,
@@ -60,11 +66,14 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		staticTestFiles: 'tests/**/*.{html,css,json,xml,js,txt}',
 		staticDefinitionFiles: '**/*.d.ts',
 		devDirectory: '<%= tsconfig.compilerOptions.outDir %>',
+		apiDocDirectory: '_apidoc',
+		apiPubDirectory: '_apipub',
 		distDirectory: 'dist/umd/',
 		otherOptions: otherOptions,
 		devTasks,
 		distTasks,
-		distESMTasks
+		distESMTasks,
+		docTasks
 	});
 
 	const options: { [option: string]: any } = {};
@@ -90,6 +99,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	}
 
 	require('./tasks/ts')(grunt);
+	require('./tasks/typedoc')(grunt);
 
 	// Set some Intern-specific options if specified on the command line.
 	[ 'suites', 'functionalSuites', 'grep' ].forEach(function (option) {
@@ -134,6 +144,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	grunt.registerTask('dev', grunt.config.get<string[]>('devTasks'));
 	grunt.registerTask('dist', grunt.config.get<string[]>('distTasks'));
 	grunt.registerTask('dist_esm', grunt.config.get<string[]>('distESMTasks'));
+	grunt.registerTask('doc', grunt.config.get<string[]>('docTasks'));
 
 	grunt.registerTask('default', [ 'clean', 'dev' ]);
 };

--- a/options/clean.ts
+++ b/options/clean.ts
@@ -28,6 +28,9 @@ export = function (grunt: IGrunt) {
 		},
 		coverage: {
 			src: [ 'coverage-unmapped.json' ]
+		},
+		typedoc: {
+			src: [ '<%= apiDocDirectory %>', '<%= apiPubDirectory %>' ]
 		}
 	};
 };

--- a/options/typedoc.ts
+++ b/options/typedoc.ts
@@ -5,7 +5,7 @@ export = function (grunt: IGrunt) {
 		options: {
 			// All options but publishOptions are passed directly to the typedoc command line.
 			mode: 'modules',
-			externalPattern: '**/+(examples|node_modules|tests|typings)/**/*.ts',
+			externalPattern: '**/+(example|examples|node_modules|tests|typings)/**/*.ts',
 			excludeExternals: true,
 			excludeNotExported: true,
 			includeDeclarations: true,

--- a/options/typedoc.ts
+++ b/options/typedoc.ts
@@ -6,6 +6,8 @@ export = function (grunt: IGrunt) {
 			// All options but publishOptions are passed directly to the typedoc command line.
 			mode: 'modules',
 			externalPattern: '**/+(example|examples|node_modules|tests|typings)/**/*.ts',
+			// TODO: A dummy exclude pattern is required for typedoc 0.5.6
+			exclude: '_',
 			excludeExternals: true,
 			excludeNotExported: true,
 			includeDeclarations: true,

--- a/options/typedoc.ts
+++ b/options/typedoc.ts
@@ -5,7 +5,7 @@ export = function (grunt: IGrunt) {
 		options: {
 			// All options but publishOptions are passed directly to the typedoc command line.
 			mode: 'modules',
-			externalPattern: '**/+(node_modules|tests|examples)/**/*.ts',
+			externalPattern: '**/+(examples|node_modules|tests|typings)/**/*.ts',
 			excludeExternals: true,
 			excludeNotExported: true,
 			includeDeclarations: true,

--- a/options/typedoc.ts
+++ b/options/typedoc.ts
@@ -5,9 +5,10 @@ export = function (grunt: IGrunt) {
 		options: {
 			// All options but publishOptions are passed directly to the typedoc command line.
 			mode: 'modules',
-			externalPattern: '**/+(tests|examples)/**/*.ts',
+			externalPattern: '**/+(node_modules|tests|examples)/**/*.ts',
 			excludeExternals: true,
 			excludeNotExported: true,
+			includeDeclarations: true,
 
 			// publishOptions are only used when publishing the generate API docs
 			publishOptions: {

--- a/options/typedoc.ts
+++ b/options/typedoc.ts
@@ -1,0 +1,27 @@
+export = function (grunt: IGrunt) {
+	const { exec } = require('shelljs');
+
+	return {
+		options: {
+			// All options but publishOptions are passed directly to the typedoc command line.
+			mode: 'modules',
+			externalPattern: '**/+(tests|examples)/**/*.ts',
+			excludeExternals: true,
+			excludeNotExported: true,
+
+			// publishOptions are only used when publishing the generate API docs
+			publishOptions: {
+				branch: 'gh-pages',
+				subdir: 'api',
+
+				// shouldPush is a function that indicates whether doc updates should be pushed to the origin
+				shouldPush: function () {
+					const branch = exec('git rev-parse --abbrev-ref HEAD', { silent: true }).stdout.trim();
+					const keyTag = process.env['SSH_KEY_TAG'];
+					const keyVar = process.env[`encrypted_${keyTag}_key`];
+					return branch === 'master' && keyVar;
+				}
+			}
+		}
+	};
+};

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "remap-istanbul": ">=0.6.3",
     "resolve-from": "^2.0.0",
     "shelljs": "^0.7.6",
-    "typedoc": "../typedoc/typedoc-0.5.5.tgz",
+    "typedoc": "^0.5.5",
     "umd-wrapper": "^0.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "postcss-modules": "^0.6.3",
     "remap-istanbul": ">=0.6.3",
     "resolve-from": "^2.0.0",
+    "shelljs": "^0.7.6",
+    "typedoc": "../typedoc/typedoc-0.5.5.tgz",
     "umd-wrapper": "^0.1.0"
   },
   "devDependencies": {
@@ -63,6 +65,7 @@
     "@types/mockery": "~1.4.29",
     "@types/node": "^7.0.0",
     "@types/sinon": "~1.16.32",
+    "@types/shelljs": "^0.6.0",
     "dojo-loader": "^2.0.0-beta.7",
     "grunt": "^1.0.1",
     "intern": "~3.4.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "remap-istanbul": ">=0.6.3",
     "resolve-from": "^2.0.0",
     "shelljs": "^0.7.6",
-    "typedoc": "^0.5.5",
+    "typedoc": "^0.5.6",
     "umd-wrapper": "^0.1.0"
   },
   "devDependencies": {

--- a/tasks/typedoc.ts
+++ b/tasks/typedoc.ts
@@ -1,5 +1,7 @@
+import ITask = grunt.task.ITask;
+
 export = function (grunt: IGrunt) {
-	grunt.registerTask('typedoc', function () {
+	grunt.registerTask('typedoc', function (this: ITask) {
 		const { config, cp, rm } = require('shelljs');
 		const { execSync } = require('child_process');
 		const { join } = require('path');

--- a/tasks/typedoc.ts
+++ b/tasks/typedoc.ts
@@ -59,7 +59,8 @@ export = function (grunt: IGrunt) {
 		}
 
 		const options: any = this.options({});
-		options.out = options.out || grunt.config.get<string>('apiDocDirectory');
+		const outOption = grunt.option<string>('doc-dir');
+		options.out = outOption || options.out || grunt.config.get<string>('apiDocDirectory');
 
 		const args: string[] = [];
 		Object.keys(options).filter(key => {

--- a/tasks/typedoc.ts
+++ b/tasks/typedoc.ts
@@ -1,0 +1,95 @@
+export = function (grunt: IGrunt) {
+	grunt.registerTask('typedoc', function () {
+		const { config, cp, rm } = require('shelljs');
+		const { execSync } = require('child_process');
+		const { join } = require('path');
+
+		function exec(command: string, options: any = {}) {
+			// Use execSync from child_process instead of shelljs.exec for better
+			// handling of pass-through stdio
+			options.encoding = options.encoding || 'utf8';
+			options.stdio = options.stdio || (options.silent ? 'pipe' : 'inherit');
+			return execSync(command, options);
+		}
+
+		function publish() {
+			const docDir = options.out;
+			const cloneDir = grunt.config.get<string>('apiPubDirectory');
+			const publishBranch = publishOptions.branch || 'gh-pages';
+			const publishDir = publishOptions.subdir || 'api';
+
+			exec(`git clone . ${cloneDir}`, { silent: true });
+
+			// Queue a task to remove the temporary clone when this task is done
+			grunt.config.set(`clean.apipub`, { src: cloneDir });
+			grunt.task.run('clean:apipub');
+
+			try {
+				exec(`git checkout ${publishBranch}`, { silent: true, cwd: cloneDir });
+			}
+			catch (error) {
+				// publish branch didn't exist, so create it
+				exec(`git checkout --orphan ${publishBranch}`, { silent: true, cwd: cloneDir });
+				exec('git rm -rf .', { silent: true, cwd: cloneDir });
+				grunt.log.writeln(`Created ${publishBranch} branch`);
+			}
+
+			rm('-rf', join(cloneDir, publishDir));
+			cp('-r', docDir, join(cloneDir, publishDir));
+
+			if (exec('git status --porcelain', { silent: true, cwd: cloneDir }) === '') {
+				grunt.log.writeln('Nothing changed');
+				return;
+			}
+
+			exec(`git add ${publishDir}`, { silent: true, cwd: cloneDir });
+			exec('git commit -m "Update API docs"', { silent: true, cwd: cloneDir });
+
+			// push changes from the temporary clone to the local repo
+			exec('git push', { silent: true, cwd: cloneDir });
+			grunt.log.writeln(`Updated ${publishBranch} in local repo`);
+
+			// push changes from the local repo to the origin repo
+			exec(`git push origin ${publishBranch}`, { silent: true });
+			grunt.log.writeln(`Pushed ${publishBranch} to origin`);
+		}
+
+		const options: any = this.options({});
+		options.out = options.out || grunt.config.get<string>('apiDocDirectory');
+
+		const args: string[] = [];
+		Object.keys(options).filter(key => {
+			return key !== 'publishOptions';
+		}).forEach(key => {
+			if (typeof options[key] === 'boolean') {
+				if (options[key]) {
+					args.push('--' + key);
+				}
+			}
+			else if (options[key]) {
+				args.push('--' + key);
+				args.push(`"${options[key]}"`);
+			}
+		});
+
+		// Throw when any shelljs command fails
+		config.fatal = true;
+
+		// Use project-local typedoc
+		const typedoc = require.resolve('typedoc/bin/typedoc');
+		exec(`node "${typedoc}" ${args.join(' ')}`);
+
+		const publishOptions = options.publishOptions || {};
+
+		if (grunt.option('publish-api')) {
+			const shouldPush = publishOptions.shouldPush || (() => true);
+			if (!shouldPush()) {
+				grunt.log.writeln('Push check failed -- not publishing API docs');
+			}
+			else {
+				grunt.log.writeln('Publishing API docs');
+				publish();
+			}
+		}
+	});
+};

--- a/tasks/typedoc.ts
+++ b/tasks/typedoc.ts
@@ -1,7 +1,5 @@
 import ITask = grunt.task.ITask;
 import { config, cp, rm } from 'shelljs';
-import { dirname, relative } from 'path';
-import { cloneDeep } from 'lodash';
 import { execSync } from 'child_process';
 import { join } from 'path';
 
@@ -60,52 +58,12 @@ export = function (grunt: IGrunt) {
 			grunt.log.writeln(`Pushed ${publishBranch} to origin`);
 		}
 
-		/**
-		 * typedoc <= 0.5.5 breaks TS's automatic type discovery, and also leaves out important compiler flags like
-		 * strictNullChecks. Fake the type discovery, and ignore remaining errors.
-		 *
-		 * TODO: Remove this when TypeDoc has been updated.
-		 */
-		function setupForOldTypedoc() {
-			const typedocInfo = grunt.file.readJSON(require.resolve('typedoc/package.json'));
-			const [ major, minor, patch ] = typedocInfo.version.split('.').map(Number);
-			if (major > 0 || minor > 5 || patch > 5) {
-				return false;
-			}
-
-			grunt.loadNpmTasks('grunt-ts');
-			const tsconfig: any = options.tsconfig ? grunt.file.readJSON(options.tsconfig) :
-				cloneDeep(grunt.config.get('tsconfig'));
-
-			const tsconfigFileName = join(dirname(options.out), '.tsconfig-typedoc.json');
-			const base = dirname(relative(dirname(tsconfigFileName), 'node_modules'));
-
-			// The type paths need to be relative to the temp tsconfig file that will be created
-			const installedTypes = grunt.file.expandMapping(['node_modules/@types/*/index.d.ts'], base, {}).map(mapping => {
-				return mapping.dest;
-			});
-			if (installedTypes.length > 0) {
-				tsconfig.include = installedTypes.concat(tsconfig.include || []);
-			}
-
-			// Put temp tsconfig file in same directory as output
-			grunt.file.write(tsconfigFileName, JSON.stringify(tsconfig, null, '  '));
-			args.push('--tsconfig', `"${tsconfigFileName}"`);
-
-			grunt.config.set('clean.typedocTsconfig', { src: tsconfigFileName});
-			grunt.task.run('clean:typedocTsconfig');
-
-			args.push('--ignoreCompilerErrors');
-
-			return true;
-		}
-
 		const options: any = this.options({});
 		options.out = options.out || grunt.config.get<string>('apiDocDirectory');
 
 		const args: string[] = [];
 		Object.keys(options).filter(key => {
-			return key !== 'publishOptions' && key !== 'tsconfig';
+			return key !== 'publishOptions';
 		}).forEach(key => {
 			if (typeof options[key] === 'boolean') {
 				if (options[key]) {
@@ -117,10 +75,6 @@ export = function (grunt: IGrunt) {
 				args.push(`"${options[key]}"`);
 			}
 		});
-
-		if (!setupForOldTypedoc() && options.tsconfig) {
-			args.push('--tsconfig', `"${options.tsconfig}"`);
-		}
 
 		// Use project-local typedoc
 		const typedoc = require.resolve('typedoc/bin/typedoc');

--- a/tasks/typedoc.ts
+++ b/tasks/typedoc.ts
@@ -1,10 +1,14 @@
 import ITask = grunt.task.ITask;
+import { config, cp, rm } from 'shelljs';
+import { dirname, relative } from 'path';
+import { cloneDeep } from 'lodash';
+import { execSync } from 'child_process';
+import { join } from 'path';
 
 export = function (grunt: IGrunt) {
 	grunt.registerTask('typedoc', function (this: ITask) {
-		const { config, cp, rm } = require('shelljs');
-		const { execSync } = require('child_process');
-		const { join } = require('path');
+		// Throw when any shelljs command fails
+		config.fatal = true;
 
 		function exec(command: string, options: any = {}) {
 			// Use execSync from child_process instead of shelljs.exec for better
@@ -56,12 +60,52 @@ export = function (grunt: IGrunt) {
 			grunt.log.writeln(`Pushed ${publishBranch} to origin`);
 		}
 
+		/**
+		 * typedoc <= 0.5.5 breaks TS's automatic type discovery, and also leaves out important compiler flags like
+		 * strictNullChecks. Fake the type discovery, and ignore remaining errors.
+		 *
+		 * TODO: Remove this when TypeDoc has been updated.
+		 */
+		function setupForOldTypedoc() {
+			const typedocInfo = grunt.file.readJSON(require.resolve('typedoc/package.json'));
+			const [ major, minor, patch ] = typedocInfo.version.split('.').map(Number);
+			if (major > 0 || minor > 5 || patch > 5) {
+				return false;
+			}
+
+			grunt.loadNpmTasks('grunt-ts');
+			const tsconfig: any = options.tsconfig ? grunt.file.readJSON(options.tsconfig) :
+				cloneDeep(grunt.config.get('tsconfig'));
+
+			const tsconfigFileName = join(dirname(options.out), '.tsconfig-typedoc.json');
+			const base = dirname(relative(dirname(tsconfigFileName), 'node_modules'));
+
+			// The type paths need to be relative to the temp tsconfig file that will be created
+			const installedTypes = grunt.file.expandMapping(['node_modules/@types/*/index.d.ts'], base, {}).map(mapping => {
+				return mapping.dest;
+			});
+			if (installedTypes.length > 0) {
+				tsconfig.include = installedTypes.concat(tsconfig.include || []);
+			}
+
+			// Put temp tsconfig file in same directory as output
+			grunt.file.write(tsconfigFileName, JSON.stringify(tsconfig, null, '  '));
+			args.push('--tsconfig', `"${tsconfigFileName}"`);
+
+			grunt.config.set('clean.typedocTsconfig', { src: tsconfigFileName});
+			grunt.task.run('clean:typedocTsconfig');
+
+			args.push('--ignoreCompilerErrors');
+
+			return true;
+		}
+
 		const options: any = this.options({});
 		options.out = options.out || grunt.config.get<string>('apiDocDirectory');
 
 		const args: string[] = [];
 		Object.keys(options).filter(key => {
-			return key !== 'publishOptions';
+			return key !== 'publishOptions' && key !== 'tsconfig';
 		}).forEach(key => {
 			if (typeof options[key] === 'boolean') {
 				if (options[key]) {
@@ -74,29 +118,8 @@ export = function (grunt: IGrunt) {
 			}
 		});
 
-		// Throw when any shelljs command fails
-		config.fatal = true;
-
-		// TODO: typedoc <= 0.5.5 breaks TS's automatic type discovery, and also leaves out important
-		// compiler flags like strictNullChecks. Fake the type discovery, and ignore remaining errors.
-		const typedocInfo = grunt.file.readJSON(require.resolve('typedoc/package.json'));
-		const [ major, minor, patch ] = typedocInfo.version.split('.');
-		if (major === '0' && Number(minor) <= 5 && Number(patch) <= 5) {
-			grunt.loadNpmTasks('grunt-ts');
-			const { cloneDeep } = require('lodash');
-			const tsconfig: any = cloneDeep(grunt.config.get('tsconfig'));
-			const installedTypes = grunt.file.expand(['./node_modules/@types/*/index.d.ts']);
-			if (installedTypes.length > 0) {
-				tsconfig.include = installedTypes.concat(tsconfig.include || []);
-			}
-			const tsconfigFileName = '.tsconfig-typedoc.json';
-			grunt.file.write(tsconfigFileName, JSON.stringify(tsconfig, null, '  '));
-			args.push('--tsconfig', tsconfigFileName);
-
-			grunt.config.set('clean.typedocTsconfig', { src: tsconfigFileName});
-			grunt.task.run('clean:typedocTsconfig');
-
-			args.push('--ignoreCompilerErrors');
+		if (!setupForOldTypedoc() && options.tsconfig) {
+			args.push('--tsconfig', `"${options.tsconfig}"`);
 		}
 
 		// Use project-local typedoc
@@ -106,7 +129,7 @@ export = function (grunt: IGrunt) {
 		const publishOptions = options.publishOptions || {};
 
 		if (grunt.option('publish-api')) {
-			const shouldPush = publishOptions.shouldPush || (() => true);
+			const shouldPush = publishOptions.shouldPush || (() => false);
 			if (!shouldPush()) {
 				grunt.log.writeln('Push check failed -- not publishing API docs');
 			}

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -13,3 +13,5 @@ export const excludeInstrumentation = /^(?:tests|node_modules)\//;
 export const loaders = {
 	'host-node': 'dojo-loader'
 };
+
+export const filterErrorStack = true;

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -7,6 +7,7 @@ define([
 	'./tasks/repl',
 	'./tasks/run',
 	'./tasks/ts',
+	'./tasks/typedoc',
 	'./tasks/uploadCoverage',
 	'./lib/load-dojo-loader'
 ], function () {});

--- a/tests/unit/tasks/typedoc.ts
+++ b/tests/unit/tasks/typedoc.ts
@@ -1,0 +1,208 @@
+import registerSuite = require('intern!object');
+import { assert } from 'chai';
+import * as grunt from 'grunt';
+import { join } from 'path';
+import { SinonSpy, spy, SinonStub, stub } from 'sinon';
+import {
+	loadTasks, prepareOutputDirectory, unloadTasks, cleanOutputDirectory, runGruntTask,
+	getOutputDirectory
+} from '../util';
+
+const outputPath = getOutputDirectory();
+const tsconfigPath = join(outputPath, 'tsconfig.json');
+const apiDocDirectory = join(outputPath, 'doc');
+const apiPubDirectory = join(outputPath, 'pub');
+
+let loadNpmTasks: SinonStub;
+let run: SinonStub;
+let write: SinonSpy;
+let readJSON: SinonStub;
+let expandMapping: SinonStub;
+let publishApi: boolean;
+let execSync: SinonSpy;
+let cp: SinonSpy;
+let rm: SinonSpy;
+let typedocVersion: string;
+let shouldPush: SinonSpy;
+let shouldPushValue: boolean;
+let failInitialCheckout: boolean;
+
+registerSuite({
+	name: 'tasks/typedoc',
+
+	setup() {
+		cp = spy(() => {});
+		rm = spy(() => {});
+		execSync = spy((command: string) => {
+			if (/git checkout/.test(command) && failInitialCheckout) {
+				failInitialCheckout = false;
+				throw new Error('Failing checkout');
+			}
+		});
+
+		loadTasks({
+			'shelljs': {
+				config: {},
+				cp,
+				rm
+			},
+			'child_process': {
+				execSync
+			}
+		});
+
+		loadNpmTasks = stub(grunt, 'loadNpmTasks');
+		run = stub(grunt.task, 'run');
+		write = spy(grunt.file, 'write');
+		expandMapping = stub(grunt.file, 'expandMapping', (patterns: string[], base: string) => {
+			return [ 'foo' ];
+		});
+		readJSON = stub(grunt.file, 'readJSON', (filename: string) => {
+			if (filename.indexOf('package.json') !== -1) {
+				return {
+					version: typedocVersion
+				};
+			}
+			else {
+				return {};
+			}
+		});
+		shouldPush = spy(() => shouldPushValue);
+
+		prepareOutputDirectory();
+
+		publishApi = grunt.option<boolean>('publish-api');
+	},
+
+	teardown() {
+		loadNpmTasks.restore();
+		write.restore();
+		run.restore();
+		readJSON.restore();
+		expandMapping.restore();
+
+		unloadTasks();
+		cleanOutputDirectory();
+
+		grunt.option('publish-api', publishApi);
+	},
+
+	beforeEach() {
+		grunt.initConfig({
+			apiDocDirectory,
+			apiPubDirectory,
+			tsconfig: {
+				compilerOptions: {
+					inlineSourceMap: true,
+					inlineSources: true,
+					listFiles: true,
+					module: 'commonjs',
+					noImplicitAny: true,
+					pretty: true,
+					target: 'es5'
+				}
+			},
+			typedoc: {
+				options: {
+					mode: 'modules',
+					excludeExternals: true,
+					excludeNotExported: true,
+					tsconfig: tsconfigPath,
+					logger: 'none',
+					publishOptions: {
+						subdir: 'api',
+						shouldPush
+					}
+				}
+			}
+		});
+
+		write.reset();
+		execSync.reset();
+		shouldPush.reset();
+
+		shouldPushValue = false;
+		failInitialCheckout = false;
+	},
+
+	default: {
+		// TODO: Remove this check after updating to TypeDoc 0.5.6+
+		'old typedoc'() {
+			typedocVersion = '0.5.5';
+			runGruntTask('typedoc');
+			assert.strictEqual(shouldPush.callCount, 0, 'Push check should not have been called');
+			assert.strictEqual(write.callCount, 1, 'One file should have been written');
+			assert.strictEqual(execSync.callCount, 1, 'Unexpected number of exec calls');
+		},
+
+		'new typedoc'() {
+			typedocVersion = '0.5.6';
+			runGruntTask('typedoc');
+			assert.strictEqual(shouldPush.callCount, 0, 'Push check should not have been called');
+			assert.strictEqual(write.callCount, 0, 'Nothing should have been written');
+			assert.strictEqual(execSync.callCount, 1, 'Unexpected number of exec calls');
+		},
+
+		'typedoc command'() {
+			typedocVersion = '0.5.6';
+			runGruntTask('typedoc');
+			const command = execSync.args[0][0];
+			const matcher = new RegExp(
+				`node "[^"]+/typedoc" --mode "modules" --excludeExternals --excludeNotExported ` +
+				`--logger "none" --out "${apiDocDirectory}" --tsconfig "${join(outputPath, 'tsconfig.json')}"`);
+			assert.match(command, matcher, 'Unexpected typedoc command line');
+		}
+	},
+
+	publish: (() => {
+		let publishApi: boolean;
+
+		return {
+			setup() {
+				publishApi = grunt.option<boolean>('publish-api');
+				grunt.option('publish-api', true);
+				typedocVersion = '0.5.6';
+			},
+
+			teardown() {
+				grunt.option('publish-api', publishApi);
+			},
+
+			'should push': {
+				beforeEach() {
+					shouldPushValue = true;
+				},
+
+				'gh-pages exists'() {
+					runGruntTask('typedoc');
+					assert.strictEqual(shouldPush.callCount, 1, 'Push check should have been called once');
+					assert.strictEqual(execSync.callCount, 8, 'Unexpected number of exec calls');
+				},
+
+				'gh-pages does not exist'() {
+					failInitialCheckout = true;
+					runGruntTask('typedoc');
+					assert.strictEqual(shouldPush.callCount, 1, 'Push check should have been called once');
+					// There should be more exec calls when gh-pages doesn't exist
+					assert.strictEqual(execSync.callCount, 10, 'Unexpected number of exec calls');
+				}
+			},
+
+			'should not push': {
+				'checker in options'() {
+					shouldPushValue = false;
+					runGruntTask('typedoc');
+					assert.strictEqual(shouldPush.callCount, 1, 'Push check should have been called once');
+					assert.strictEqual(execSync.callCount, 1, 'Unexpected number of exec calls');
+				},
+
+				'default checker'() {
+					// With no shouldPush config value, the default should be not to push
+					grunt.config.set('typedoc.options.publishOptions.shouldPush', undefined);
+					runGruntTask('typedoc');
+					assert.strictEqual(execSync.callCount, 1, 'Unexpected number of exec calls');
+				}
+			}
+		};
+	})()
+});

--- a/tests/unit/tasks/typedoc.ts
+++ b/tests/unit/tasks/typedoc.ts
@@ -22,7 +22,6 @@ let publishApi: boolean;
 let execSync: SinonSpy;
 let cp: SinonSpy;
 let rm: SinonSpy;
-let typedocVersion: string;
 let shouldPush: SinonSpy;
 let shouldPushValue: boolean;
 let failInitialCheckout: boolean;
@@ -58,14 +57,7 @@ registerSuite({
 			return [ 'foo' ];
 		});
 		readJSON = stub(grunt.file, 'readJSON', (filename: string) => {
-			if (filename.indexOf('package.json') !== -1) {
-				return {
-					version: typedocVersion
-				};
-			}
-			else {
-				return {};
-			}
+			return {};
 		});
 		shouldPush = spy(() => shouldPushValue);
 
@@ -125,33 +117,17 @@ registerSuite({
 		failInitialCheckout = false;
 	},
 
-	default: {
-		// TODO: Remove this check after updating to TypeDoc 0.5.6+
-		'old typedoc'() {
-			typedocVersion = '0.5.5';
-			runGruntTask('typedoc');
-			assert.strictEqual(shouldPush.callCount, 0, 'Push check should not have been called');
-			assert.strictEqual(write.callCount, 1, 'One file should have been written');
-			assert.strictEqual(execSync.callCount, 1, 'Unexpected number of exec calls');
-		},
-
-		'new typedoc'() {
-			typedocVersion = '0.5.6';
-			runGruntTask('typedoc');
-			assert.strictEqual(shouldPush.callCount, 0, 'Push check should not have been called');
-			assert.strictEqual(write.callCount, 0, 'Nothing should have been written');
-			assert.strictEqual(execSync.callCount, 1, 'Unexpected number of exec calls');
-		},
-
-		'typedoc command'() {
-			typedocVersion = '0.5.6';
-			runGruntTask('typedoc');
-			const command = execSync.args[0][0];
-			const matcher = new RegExp(
-				`node "[^"]+/typedoc" --mode "modules" --excludeExternals --excludeNotExported ` +
-				`--logger "none" --out "${apiDocDirectory}" --tsconfig "${join(outputPath, 'tsconfig.json')}"`);
-			assert.match(command, matcher, 'Unexpected typedoc command line');
-		}
+	default() {
+		runGruntTask('typedoc');
+		const command = execSync.args[0][0];
+		const matcher = new RegExp(
+			`node "[^"]+/typedoc" --mode "modules" --excludeExternals --excludeNotExported ` +
+			`--tsconfig "${join(outputPath, 'tsconfig.json')}" ` +
+			`--logger "none" --out "${apiDocDirectory}"`);
+		assert.match(command, matcher, 'Unexpected typedoc command line');
+		assert.strictEqual(shouldPush.callCount, 0, 'Push check should not have been called');
+		assert.strictEqual(write.callCount, 0, 'Nothing should have been written');
+		assert.strictEqual(execSync.callCount, 1, 'Unexpected number of exec calls');
 	},
 
 	publish: (() => {
@@ -161,7 +137,6 @@ registerSuite({
 			setup() {
 				publishApi = grunt.option<boolean>('publish-api');
 				grunt.option('publish-api', true);
-				typedocVersion = '0.5.6';
 			},
 
 			teardown() {

--- a/tests/unit/util.ts
+++ b/tests/unit/util.ts
@@ -2,7 +2,6 @@ import * as grunt from 'grunt';
 import * as path from 'path';
 import * as mockery from 'mockery';
 import * as _ from 'lodash';
-import ITask = grunt.task.ITask;
 
 export interface MockList {
 	[key: string]: any;
@@ -11,7 +10,7 @@ export interface MockList {
 export interface TaskLoadingOptions {
 	peerDependencies?: {
 		[key: string]: any;
-	}
+	};
 }
 
 export function createDummyFile(name: string, data?: string) {
@@ -21,7 +20,7 @@ export function createDummyFile(name: string, data?: string) {
 }
 
 export function createDummyDirectory(name: string) {
-	var filePath = path.join(getInputDirectory(), name);
+	const filePath = path.join(getInputDirectory(), name);
 	grunt.file.mkdir(filePath);
 }
 
@@ -50,7 +49,7 @@ export function cleanOutputDirectory() {
 }
 
 export function runGruntTask(taskName: string, callback?: () => void) {
-	var task = (<any> grunt.task)._taskPlusArgs(taskName);
+	const task = (<any> grunt.task)._taskPlusArgs(taskName);
 
 	return task.task.fn.apply({
 		nameArgs: task.nameArgs,
@@ -85,17 +84,17 @@ export function loadTasks(mocks?: MockList, options?: TaskLoadingOptions) {
 	mockery.registerMock('postcss-modules', function noop() {});
 
 	if (mocks) {
-		var keys = Object.keys(mocks);
+		const keys = Object.keys(mocks);
 
-		for (var i = 0; i < keys.length; i++) {
-			mockery.registerMock(keys[ i ], mocks[ keys[ i ] ]);
+		for (let i = 0; i < keys.length; i++) {
+			mockery.registerMock(keys[i], mocks[keys[i]]);
 		}
 	}
 
 	grunt.registerTask('clean', 'Clean mock task', () => {
 	});
 
-	var packageJson = grunt.file.readJSON('package.json');
+	const packageJson = grunt.file.readJSON('package.json');
 
 	if (options && options.peerDependencies) {
 		packageJson.peerDependencies = options.peerDependencies;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
 	"compilerOptions": {
 		"inlineSourceMap": true,
 		"inlineSources": true,
-		"listFiles": true,
 		"module": "umd",
 		"moduleResolution": "node",
 		"noImplicitAny": true,


### PR DESCRIPTION
This PR adds a typedoc task with support for publishing docs to a repo's gh-pages branch. The PR includes code for mitigating some issues with typedoc <= 0.5.5 that should be unnecessary for 0.5.6+.

Running `grunt doc` will install necessary types and generate API documentation. Adding a `--publish-api` option will attempt to publish the API docs to the repo's gh-pages branch.