### PR TITLE
Update PR/Issue/Contributing templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Thank You
+
+We very much welcome contributions to Dojo 2.
+
+Because we have so many repositories that are part of Dojo 2, we have located our [Contributing Guidelines](https://github.com/dojo/meta/blob/master/CONTRIBUTING.md) in our [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme).
+
+Look forward to working with you on Dojo 2!!!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+Thank you for contributing to Dojo 2.
+
+Our issue tracker is for bugs for Dojo 2.
+
+Please make sure you have read our Contributing Guidelines
+available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
+
+For general questions and discussion, join us on Gitter.im at: https://gitter.im/dojo/dojo2
+-->
+
+**Bug / Enhancement** <!-- delete as appropriate -->
+
+<!-- Summary of enhancement or bug-->
+
+Package Version: <!-- package version -->
+
+**Code**
+
+<!-- a self contained example of code that demonstrates the issue -->
+
+**Expected behavior:**
+
+<!-- What did you expect to happen -->
+
+**Actual behavior:**
+
+<!-- What was the actual behavior? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+**Type:** bug / feature
+
+The following has been addressed in the PR:
+
+* [ ] There is a related issue
+* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] Unit or Functional tests are included in the PR
+
+<!--
+Our bots should ensure:
+
+* [ ] All contributors have signed a CLA
+* [ ] The PR passes CI testing
+* [ ] Code coverage is maintained
+* [ ] The PR has been reviewed and approved
+-->
+
+**Description:**
+
+Resolves #???


### PR DESCRIPTION
**Type:** bug

**Description:** 

Normalising PR/Issue/Contributing to the current template.

**Related Issue:** https://github.com/dojo/meta/issues/147