### PR TITLE
Pass `--peer` when using `yarn` to install `peerDependencies`

### DIFF
--- a/tasks/installPeerDependencies.ts
+++ b/tasks/installPeerDependencies.ts
@@ -3,7 +3,7 @@ import { execSync as exec } from 'child_process';
 export = function(grunt: IGrunt, packageJson: any) {
 	grunt.registerTask('peerDepInstall', <any> function () {
 		const peerDeps = packageJson.peerDependencies;
-		let packageCmd = 'yarn add --ignore-engines';
+		let packageCmd = 'yarn add --ignore-engines --peer';
 
 		try {
 			exec('yarn --version');

--- a/tests/unit/tasks/installPeerDependencies.ts
+++ b/tests/unit/tasks/installPeerDependencies.ts
@@ -53,8 +53,8 @@ registerSuite({
 
 			mockShell
 			.withArgs('yarn --version').returns(Promise.resolve({}))
-			.withArgs('yarn add --ignore-engines my-dep@"1.0"').returns(Promise.resolve({}))
-			.withArgs('yarn add --ignore-engines error-dep@"1.0"').throws();
+			.withArgs('yarn add --ignore-engines --peer my-dep@"1.0"').returns(Promise.resolve({}))
+			.withArgs('yarn add --ignore-engines --peer error-dep@"1.0"').throws();
 
 			loadTasks({
 				child_process: {
@@ -71,8 +71,8 @@ registerSuite({
 			runGruntTask('peerDepInstall');
 
 			assert.isTrue(mockShell.calledThrice);
-			assert.isTrue(mockShell.calledWith('yarn add --ignore-engines my-dep@"1.0"'));
-			assert.isTrue(mockShell.calledWith('yarn add --ignore-engines error-dep@"1.0"'));
+			assert.isTrue(mockShell.calledWith('yarn add --ignore-engines --peer my-dep@"1.0"'));
+			assert.isTrue(mockShell.calledWith('yarn add --ignore-engines --peer error-dep@"1.0"'));
 			assert.isTrue(mockLogger.called);
 			assert.isTrue(mockLogger.calledWith('failed.'));
 		}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

pass `--peer` when using yarn to ensure that the dependencies are saved correctly.

Resolves #107 