### PR TITLE
Remove support for yarn

### DIFF
--- a/tasks/installPeerDependencies.ts
+++ b/tasks/installPeerDependencies.ts
@@ -3,14 +3,7 @@ import { execSync as exec } from 'child_process';
 export = function(grunt: IGrunt, packageJson: any) {
 	grunt.registerTask('peerDepInstall', <any> function () {
 		const peerDeps = packageJson.peerDependencies;
-		let packageCmd = 'yarn add --ignore-engines --peer';
-
-		try {
-			exec('yarn --version');
-		}
-		catch (error) {
-			packageCmd = 'npm install';
-		}
+		let packageCmd = 'npm install';
 
 		for (let name in peerDeps) {
 			grunt.log.write(`installing peer dependency ${name} with version ${peerDeps[name]}...`);

--- a/tests/unit/tasks/installPeerDependencies.ts
+++ b/tests/unit/tasks/installPeerDependencies.ts
@@ -44,37 +44,5 @@ registerSuite({
 			assert.isTrue(mockLogger.called);
 			assert.isTrue(mockLogger.calledWith('failed.'));
 		}
-	},
-	'yarn': {
-		beforeEach() {
-			grunt.initConfig({});
-			mockLogger = stub(grunt.log, 'error');
-			mockShell = stub();
-
-			mockShell
-			.withArgs('yarn --version').returns(Promise.resolve({}))
-			.withArgs('yarn add --ignore-engines --peer my-dep@"1.0"').returns(Promise.resolve({}))
-			.withArgs('yarn add --ignore-engines --peer error-dep@"1.0"').throws();
-
-			loadTasks({
-				child_process: {
-					execSync: mockShell
-				}
-			}, {
-				peerDependencies: {
-					'my-dep': '1.0',
-					'error-dep': '1.0'
-				}
-			});
-		},
-		runsCommands() {
-			runGruntTask('peerDepInstall');
-
-			assert.isTrue(mockShell.calledThrice);
-			assert.isTrue(mockShell.calledWith('yarn add --ignore-engines --peer my-dep@"1.0"'));
-			assert.isTrue(mockShell.calledWith('yarn add --ignore-engines --peer error-dep@"1.0"'));
-			assert.isTrue(mockLogger.called);
-			assert.isTrue(mockLogger.calledWith('failed.'));
-		}
 	}
 });

--- a/tests/unit/tasks/installPeerDependencies.ts
+++ b/tests/unit/tasks/installPeerDependencies.ts
@@ -20,7 +20,6 @@ registerSuite({
 			mockShell = stub();
 
 			mockShell
-			.withArgs('yarn --version').throws()
 			.withArgs('npm install my-dep@"1.0"').returns(Promise.resolve({}))
 			.withArgs('npm install error-dep@"1.0"').throws();
 
@@ -38,7 +37,7 @@ registerSuite({
 		runsCommands() {
 			runGruntTask('peerDepInstall');
 
-			assert.isTrue(mockShell.calledThrice);
+			assert.isTrue(mockShell.calledTwice);
 			assert.isTrue(mockShell.calledWith('npm install my-dep@"1.0"'));
 			assert.isTrue(mockShell.calledWith('npm install error-dep@"1.0"'));
 			assert.isTrue(mockLogger.called);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

`yarn` behaves differently to `npm` when installing modules - it automatically saves them as dependencies in the `package.json` which is undesirable when they are peer deps. There is a `--peer` flag that tells `yarn` to save them in the peer deps block but then `yarn` does not install any of that packages dependencies (which are needed)

Resolves #???
