### PR TITLE
Updates to grunt typedoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lcov.info
 .tsConfig*.json
 html-report
 coverage-final.json
+deploy_key

--- a/README.md
+++ b/README.md
@@ -168,10 +168,10 @@ instead.
 
 ##### Environment Variables
 
-Running `grunt typedoc` (part of `grunt doc`) will only generate APIs using typedoc. In order automatically commit or 
- publish API documentation the `DEPLOY_DOCS` environment variable must be set to either `publish` or `commit`.
- Environment variables are used so they may be turned on/off using travis-ci settings and to support forks that may 
- want to use the travis build, but do not want to automatically publish documentation.
+Running `grunt typedoc` (part of `grunt doc`) will only generate APIs using typedoc. In order to 
+ automatically commit or publish API documentation the `DEPLOY_DOCS` environment variable must be set to either 
+ `publish` or `commit`. Environment variables are used so they may be turned on/off using travis-ci settings and to 
+ support forks that may want to use the travis build, but do not want to automatically publish documentation.
 
 ##### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,31 @@ proxy: {
 }
 ```
 
+#### grunt doc
+
+The `doc` task is used to automatically build and publish API documentation to the project's GitHub pages. Please note
+that if you want to generate documentation locally by manually running this command use the `grunt typedoc` command 
+instead.
+
+##### Environment Variables
+
+Running `grunt typedoc` (part of `grunt doc`) will only generate APIs using typedoc. In order automatically commit or 
+ publish API documentation the `DEPLOY_DOCS` environment variable must be set to either `publish` or `commit`.
+ Environment variables are used so they may be turned on/off using travis-ci settings and to support forks that may 
+ want to use the travis build, but do not want to automatically publish documentation.
+
+##### Prerequisites
+
+To support continuous delivery of API documents to your project's GitHub pages Travis-ci needs access to your GitHub
+repository. This is best achieved by supplying an encrypted deployment key that can be used via SSH (there are other
+methods that are less secure that we will not go into). To use this method you will need to:
+
+1. Create a ssh key; e.g. `ssh-keygen -t rsa -C "your_email@example.com"`
+1. encrypt the private key using travis cli; e.g. `travis encrypt-file deploy_key` (you will need to be logged in and
+	be the owner of the GitHub repository to do this)
+1. add the public key under your project's GitHub settings
+1. add `grunt doc --publish-api` as part of your `install` steps
+
 #### grunt link
 
 The link task is designed to ease the local development and testing of changes that span multiple packages. Traditionally `npm link` can be used but this assumes that the project structure is the same as the distribution, which for dojo2 projects is not the case. 
@@ -219,6 +244,16 @@ The running `grunt dist` will execute the dist pipeline which as follows:
 - `tslint`
 - `clean:dist`
 - `ts:dist`
+
+#### doc
+
+Running `grunt doc` will execute the doc pipeline, which comes from the `docTasks` configuration:
+
+- `clean:typings`
+- `typings:dev`
+- `typedoc`
+- `clean:typedoc`
+- `clean:ghpages`
 
 #### test
 

--- a/index.ts
+++ b/index.ts
@@ -51,7 +51,9 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	const docTasks = [
 		'clean:typings',
 		'typings:dev',
-		'typedoc'
+		'typedoc',
+		'clean:typedoc',
+		'clean:ghpages'
 	];
 
 	grunt.initConfig({

--- a/options/clean.ts
+++ b/options/clean.ts
@@ -31,6 +31,9 @@ export = function (grunt: IGrunt) {
 		},
 		typedoc: {
 			src: [ '<%= apiDocDirectory %>', '<%= apiPubDirectory %>' ]
+		},
+		ghpages: {
+			src: [ '<%= apiPubDirectory %>' ]
 		}
 	};
 };

--- a/options/typedoc.ts
+++ b/options/typedoc.ts
@@ -1,6 +1,4 @@
-export = function (grunt: IGrunt) {
-	const { exec } = require('shelljs');
-
+export = function (_grunt: IGrunt) {
 	return {
 		options: {
 			// All options but publishOptions are passed directly to the typedoc command line.
@@ -16,14 +14,7 @@ export = function (grunt: IGrunt) {
 			publishOptions: {
 				branch: 'gh-pages',
 				subdir: 'api',
-				encryptedDeployKey: 'deploy_key.enc',
-				deployKeyTag: process.env.DEPLOY_KEY_TAG,
-
-				// shouldPush is a function that indicates whether doc updates should be pushed to the origin
-				shouldPush: function () {
-					const branch = exec('git rev-parse --abbrev-ref HEAD', { silent: true }).stdout.trim();
-					return branch === 'master';
-				}
+				deployKey: 'deploy_key'
 			}
 		}
 	};

--- a/options/typedoc.ts
+++ b/options/typedoc.ts
@@ -16,13 +16,12 @@ export = function (grunt: IGrunt) {
 			publishOptions: {
 				branch: 'gh-pages',
 				subdir: 'api',
+				encryptedDeployKey: 'deploy_key.enc',
 
 				// shouldPush is a function that indicates whether doc updates should be pushed to the origin
 				shouldPush: function () {
 					const branch = exec('git rev-parse --abbrev-ref HEAD', { silent: true }).stdout.trim();
-					const keyTag = process.env['SSH_KEY_TAG'];
-					const keyVar = process.env[`encrypted_${keyTag}_key`];
-					return branch === 'master' && keyVar;
+					return branch === 'master';
 				}
 			}
 		}

--- a/options/typedoc.ts
+++ b/options/typedoc.ts
@@ -17,6 +17,7 @@ export = function (grunt: IGrunt) {
 				branch: 'gh-pages',
 				subdir: 'api',
 				encryptedDeployKey: 'deploy_key.enc',
+				deployKeyTag: process.env.DEPLOY_KEY_TAG,
 
 				// shouldPush is a function that indicates whether doc updates should be pushed to the origin
 				shouldPush: function () {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "main": "index.js",
   "scripts": {
+    "build": "tsc",
     "prepublish": "shx rm -rf ./typings && typings install && tsc -p .",
     "test": "tests/run.sh"
   },

--- a/tasks/typedoc.ts
+++ b/tasks/typedoc.ts
@@ -13,14 +13,12 @@ function typedocOptions(options: any) {
 	Object.keys(options).filter(key => {
 		return key !== 'publishOptions';
 	}).forEach(key => {
-		if (typeof options[key] === 'boolean') {
-			if (options[key]) {
-				args.push('--' + key);
+		if (options[key]) {
+			args.push(`--${key}`);
+
+			if (typeof options[key] !== 'boolean') {
+				args.push(`"${options[key]}"`);
 			}
-		}
-		else if (options[key]) {
-			args.push('--' + key);
-			args.push(`"${options[key]}"`);
 		}
 	});
 	return args;

--- a/tasks/typedoc.ts
+++ b/tasks/typedoc.ts
@@ -1,7 +1,8 @@
 import ITask = grunt.task.ITask;
-import { config } from 'shelljs';
+import { config, touch } from 'shelljs';
 import exec from './util/exec';
 import Publisher from './util/Publisher';
+import { join } from 'path';
 
 /**
  * Build command line arguments for typedoc from grunt options
@@ -39,6 +40,10 @@ export = function (grunt: IGrunt) {
 		// Use project-local typedoc
 		const typedoc = require.resolve('typedoc/bin/typedoc');
 		exec(`node "${ typedoc }" ${ typedocOptions(options).join(' ') }`);
+
+		// Add a .nojekyll file to prevent GitHub pages from trying to parse files starting with an underscore
+		// @see https://github.com/blog/572-bypassing-jekyll-on-github-pages
+		touch(join(options.out, '.nojekyll'));
 
 		if (shouldPublish) {
 			const cloneDir = grunt.config.get<string>('apiPubDirectory');

--- a/tasks/typedoc.ts
+++ b/tasks/typedoc.ts
@@ -1,97 +1,52 @@
 import ITask = grunt.task.ITask;
-import { config, cp, rm } from 'shelljs';
-import { execSync } from 'child_process';
-import { join } from 'path';
+import { config } from 'shelljs';
+import exec from './util/exec';
+import Publisher from './util/Publisher';
+
+/**
+ * Build command line arguments for typedoc from grunt options
+ * @param options grunt options
+ * @return {string[]} command line arguments array
+ */
+function typedocOptions(options: any) {
+	const args: string[] = [];
+	Object.keys(options).filter(key => {
+		return key !== 'publishOptions';
+	}).forEach(key => {
+		if (typeof options[key] === 'boolean') {
+			if (options[key]) {
+				args.push('--' + key);
+			}
+		}
+		else if (options[key]) {
+			args.push('--' + key);
+			args.push(`"${options[key]}"`);
+		}
+	});
+	return args;
+}
 
 export = function (grunt: IGrunt) {
 	grunt.registerTask('typedoc', function (this: ITask) {
 		// Throw when any shelljs command fails
 		config.fatal = true;
 
-		function exec(command: string, options: any = {}) {
-			// Use execSync from child_process instead of shelljs.exec for better
-			// handling of pass-through stdio
-			options.encoding = options.encoding || 'utf8';
-			options.stdio = options.stdio || (options.silent ? 'pipe' : 'inherit');
-			return execSync(command, options);
-		}
-
-		function publish() {
-			const docDir = options.out;
-			const cloneDir = grunt.config.get<string>('apiPubDirectory');
-			const publishBranch = publishOptions.branch || 'gh-pages';
-			const publishDir = publishOptions.subdir || 'api';
-
-			exec(`git clone . ${cloneDir}`, { silent: true });
-
-			// Queue a task to remove the temporary clone when this task is done
-			grunt.config.set(`clean.apipub`, { src: cloneDir });
-			grunt.task.run('clean:apipub');
-
-			try {
-				exec(`git checkout ${publishBranch}`, { silent: true, cwd: cloneDir });
-			}
-			catch (error) {
-				// publish branch didn't exist, so create it
-				exec(`git checkout --orphan ${publishBranch}`, { silent: true, cwd: cloneDir });
-				exec('git rm -rf .', { silent: true, cwd: cloneDir });
-				grunt.log.writeln(`Created ${publishBranch} branch`);
-			}
-
-			rm('-rf', join(cloneDir, publishDir));
-			cp('-r', docDir, join(cloneDir, publishDir));
-
-			if (exec('git status --porcelain', { silent: true, cwd: cloneDir }) === '') {
-				grunt.log.writeln('Nothing changed');
-				return;
-			}
-
-			exec(`git add ${publishDir}`, { silent: true, cwd: cloneDir });
-			exec('git commit -m "Update API docs"', { silent: true, cwd: cloneDir });
-
-			// push changes from the temporary clone to the local repo
-			exec('git push', { silent: true, cwd: cloneDir });
-			grunt.log.writeln(`Updated ${publishBranch} in local repo`);
-
-			// push changes from the local repo to the origin repo
-			exec(`git push origin ${publishBranch}`, { silent: true });
-			grunt.log.writeln(`Pushed ${publishBranch} to origin`);
-		}
-
 		const options: any = this.options({});
 		const outOption = grunt.option<string>('doc-dir');
 		options.out = outOption || options.out || grunt.config.get<string>('apiDocDirectory');
 
-		const args: string[] = [];
-		Object.keys(options).filter(key => {
-			return key !== 'publishOptions';
-		}).forEach(key => {
-			if (typeof options[key] === 'boolean') {
-				if (options[key]) {
-					args.push('--' + key);
-				}
-			}
-			else if (options[key]) {
-				args.push('--' + key);
-				args.push(`"${options[key]}"`);
-			}
-		});
-
 		// Use project-local typedoc
 		const typedoc = require.resolve('typedoc/bin/typedoc');
-		exec(`node "${typedoc}" ${args.join(' ')}`);
+		exec(`node "${ typedoc }" ${ typedocOptions(options).join(' ') }`);
 
-		const publishOptions = options.publishOptions || {};
+		const deploy = process.env.DEPLOY_DOCS;
+		if (deploy === 'publish' || deploy === 'commit') {
+			const cloneDir = grunt.config.get<string>('apiPubDirectory');
 
-		if (grunt.option('publish-api')) {
-			const shouldPush = publishOptions.shouldPush || (() => false);
-			if (!shouldPush()) {
-				grunt.log.writeln('Push check failed -- not publishing API docs');
-			}
-			else {
-				grunt.log.writeln('Publishing API docs');
-				publish();
-			}
+			const publisher = new Publisher(cloneDir, options.out, options.publishOptions);
+			publisher.skipPublish = deploy !== 'publish';
+			publisher.log = grunt.log;
+			publisher.publish();
 		}
 	});
 };

--- a/tasks/util/Publisher.ts
+++ b/tasks/util/Publisher.ts
@@ -23,6 +23,10 @@ const consoleLogger = {
 	}
 };
 
+export function setConfig(key: string, value: string, global: boolean = false) {
+	return exec(`git config ${ global ? '--global ' : '' }${ key } ${ value }`, false);
+}
+
 export default class Publisher {
 	/**
 	 * The branch to publish API documents
@@ -124,6 +128,9 @@ export default class Publisher {
 	private commit() {
 		const publishBranch = this.branch;
 		const publishDir = this.subDirectory;
+
+		setConfig('user.name', 'Travis CI', true);
+		setConfig('user.email', 'pshannon@sitepen.com', true);
 
 		exec(`git clone . ${ this.cloneDir }`, { silent: true });
 

--- a/tasks/util/Publisher.ts
+++ b/tasks/util/Publisher.ts
@@ -1,0 +1,184 @@
+import { join } from 'path';
+import { existsSync } from 'fs';
+import exec from './exec';
+import { cp, rm } from 'shelljs';
+import LogModule = grunt.log.LogModule;
+
+export interface Options {
+	branch?: Publisher['branch'];
+	deployKeyTag?: Publisher['deployKeyTag'];
+	encryptedDeployKey?: Publisher['encryptedDeployKey'];
+	shouldPush?: Publisher['shouldPush'];
+	subDirectory?: Publisher['subDirectory'];
+}
+
+export interface Log {
+	writeln: LogModule['writeln'];
+}
+
+const consoleLogger = {
+	writeln(this: any, info: string) {
+		console.log(info);
+		return this;
+	}
+};
+
+export default class Publisher {
+	/**
+	 * The branch to publish API documents
+	 */
+	branch: string = 'gh-pages';
+
+	/**
+	 * The temporary directory for the local git clone
+	 */
+	cloneDir: string;
+
+	log: Log = consoleLogger;
+
+	/**
+	 * The filename of the encrypted deployment file or false if one is not used
+	 */
+	encryptedDeployKey: string | boolean;
+
+	/**
+	 * Travis identifier used with encrypted files
+	 */
+	deployKeyTag?: string;
+
+	/**
+	 * If publishing should be skipped
+	 */
+	skipPublish: boolean = false;
+
+	/**
+	 * The directory to place API docs
+	 */
+	subDirectory: string = 'api';
+
+	/**
+	 * The directory where typedoc generates its docs
+	 */
+	generatedDocsDirectory: string;
+
+	constructor(cloneDir: string, generatedDocsDir: string, options: Options = {}) {
+		this.cloneDir = cloneDir;
+		this.encryptedDeployKey = options.encryptedDeployKey || false;
+		this.deployKeyTag = options.deployKeyTag;
+		this.generatedDocsDirectory = generatedDocsDir;
+
+		// optional configuration values
+		options.subDirectory && (this.subDirectory = options.subDirectory);
+		options.branch && (this.branch = options.branch);
+
+		// optional method overrides
+		options.shouldPush && (this.shouldPush = options.shouldPush);
+	}
+
+	/**
+	 * If deploy credentials
+	 * @return {boolean}
+	 */
+	hasDeployCredentials(): boolean {
+		if (typeof this.encryptedDeployKey === 'boolean') {
+			return false;
+		}
+		const keyFile = this.encryptedDeployKey;
+		const deployKeyTag = this.deployKeyTag;
+		return !!keyFile && !!deployKeyTag && existsSync(keyFile);
+	}
+
+	publish() {
+		this.commit();
+
+		if (!this.skipPublish && this.shouldPush()) {
+			this.decryptDeployKey();
+			if (this.canPublish()) {
+				this.push();
+			}
+			else {
+				this.log.writeln('Push check failed -- not publishing API docs');
+			}
+		}
+		else {
+			this.log.writeln('Only committing -- skipping push to repo');
+		}
+	}
+
+	/**
+	 * @return {boolean} indicates whether doc updates should be pushed to the origin
+	 */
+	shouldPush() {
+		const branch = exec('git rev-parse --abbrev-ref HEAD', { silent: true }).trim();
+		return branch === 'master';
+	}
+
+	/**
+	 * If configuration information exists for obtaining a deployment key and prerequisites have been met to publish
+	 */
+	private canPublish(): boolean {
+		const skipDeploymentCredentials = this.encryptedDeployKey === false;
+		return (skipDeploymentCredentials || this.hasDeployCredentials()) && this.shouldPush();
+	}
+
+	private commit() {
+		const publishBranch = this.branch;
+		const publishDir = this.subDirectory;
+
+		exec(`git clone . ${ this.cloneDir }`, { silent: true });
+
+		try {
+			exec(`git checkout ${ publishBranch }`, { silent: true, cwd: this.cloneDir });
+		}
+		catch (error) {
+			// publish branch didn't exist, so create it
+			exec(`git checkout --orphan ${ publishBranch }`, { silent: true, cwd: this.cloneDir });
+			exec('git rm -rf .', { silent: true, cwd: this.cloneDir });
+			this.log.writeln(`Created ${publishBranch} branch`);
+		}
+
+		rm('-rf', join(this.cloneDir, publishDir));
+		cp('-r', this.generatedDocsDirectory, join(this.cloneDir, publishDir));
+
+		if (exec('git status --porcelain', { silent: true, cwd: this.cloneDir }) === '') {
+			this.log.writeln('Nothing changed');
+			return;
+		}
+
+		exec(`git add ${publishDir}`, { silent: true, cwd: this.cloneDir });
+		exec('git commit -m "Update API docs"', { silent: true, cwd: this.cloneDir });
+	}
+
+	private decryptDeployKey() {
+		const keyFile = this.encryptedDeployKey;
+		const deployKeyTag = this.deployKeyTag;
+
+		if (!keyFile || !deployKeyTag) {
+			return;
+		}
+
+		exec(`openssl aes-256-cbc -K $encrypted_${ deployKeyTag }_key -iv $encrypted_${ deployKeyTag }_iv -in ${ keyFile } -out deploy_key -d`);
+		exec('chmod 600 deploy_key');
+	}
+
+	/**
+	 * Publish the document created by typedoc
+	 */
+	private push() {
+		this.log.writeln('Publishing API docs');
+		const publishBranch = this.branch || 'gh-pages';
+		// push changes from the temporary clone to the local repo
+		exec('git push', { silent: true, cwd: this.cloneDir });
+		this.log.writeln(`Updated ${publishBranch} in local repo`);
+
+		// push changes from the local repo to the origin repo
+		const pushCommand = `git push origin ${publishBranch}`;
+		if (this.hasDeployCredentials()) {
+			exec(`ssh-agent bash -c 'ssh-add deploy_key; ${ pushCommand }'`, { silent: true });
+		}
+		else {
+			exec(pushCommand);
+		}
+		this.log.writeln(`Pushed ${publishBranch} to origin`);
+	}
+}

--- a/tasks/util/Publisher.ts
+++ b/tasks/util/Publisher.ts
@@ -214,9 +214,7 @@ export default class Publisher {
 	 */
 	private push() {
 		this.log.writeln('Publishing API docs');
-		const publishBranch = this.branch || 'gh-pages';
-
-		this.execSSHAgent(`git push origin ${publishBranch}`, { silent: true, cwd: this.cloneDir });
-		this.log.writeln(`Pushed ${publishBranch} to origin`);
+		this.execSSHAgent(`git push origin ${this.branch}`, { silent: true, cwd: this.cloneDir });
+		this.log.writeln(`Pushed ${this.branch} to origin`);
 	}
 }

--- a/tasks/util/exec.ts
+++ b/tasks/util/exec.ts
@@ -1,0 +1,9 @@
+import { execSync } from 'child_process';
+
+export default function exec(command: string, options: any = {}) {
+	// Use execSync from child_process instead of shelljs.exec for better
+	// handling of pass-through stdio
+	options.encoding = options.encoding || 'utf8';
+	options.stdio = options.stdio || (options.silent ? 'pipe' : 'inherit');
+	return execSync(command, options);
+}

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -1,13 +1,25 @@
-define([
-	'./tasks/fixSourceMaps',
-	'./tasks/installPeerDependencies',
-	'./tasks/link',
-	'./tasks/release',
-	'./tasks/rename',
-	'./tasks/repl',
-	'./tasks/run',
-	'./tasks/ts',
-	'./tasks/typedoc',
-	'./tasks/uploadCoverage',
-	'./lib/load-dojo-loader'
-], function () {});
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports", "./tasks/fixSourceMaps", "./tasks/installPeerDependencies", "./tasks/link", "./tasks/release", "./tasks/rename", "./tasks/repl", "./tasks/run", "./tasks/ts", "./tasks/typedoc", "./tasks/uploadCoverage", "./tasks/util/Publisher", "./lib/load-dojo-loader"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    require("./tasks/fixSourceMaps");
+    require("./tasks/installPeerDependencies");
+    require("./tasks/link");
+    require("./tasks/release");
+    require("./tasks/rename");
+    require("./tasks/repl");
+    require("./tasks/run");
+    require("./tasks/ts");
+    require("./tasks/typedoc");
+    require("./tasks/uploadCoverage");
+    require("./tasks/util/Publisher");
+    require("./lib/load-dojo-loader");
+});
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYWxsLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiYWxsLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7Ozs7Ozs7O0lBQUEsaUNBQStCO0lBQy9CLDJDQUF5QztJQUN6Qyx3QkFBc0I7SUFDdEIsMkJBQXlCO0lBQ3pCLDBCQUF3QjtJQUN4Qix3QkFBc0I7SUFDdEIsdUJBQXFCO0lBQ3JCLHNCQUFvQjtJQUNwQiwyQkFBeUI7SUFDekIsa0NBQWdDO0lBQ2hDLGtDQUFnQztJQUNoQyxrQ0FBZ0MiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgJy4vdGFza3MvZml4U291cmNlTWFwcyc7XG5pbXBvcnQgJy4vdGFza3MvaW5zdGFsbFBlZXJEZXBlbmRlbmNpZXMnO1xuaW1wb3J0ICcuL3Rhc2tzL2xpbmsnO1xuaW1wb3J0ICcuL3Rhc2tzL3JlbGVhc2UnO1xuaW1wb3J0ICcuL3Rhc2tzL3JlbmFtZSc7XG5pbXBvcnQgJy4vdGFza3MvcmVwbCc7XG5pbXBvcnQgJy4vdGFza3MvcnVuJztcbmltcG9ydCAnLi90YXNrcy90cyc7XG5pbXBvcnQgJy4vdGFza3MvdHlwZWRvYyc7XG5pbXBvcnQgJy4vdGFza3MvdXBsb2FkQ292ZXJhZ2UnO1xuaW1wb3J0ICcuL3Rhc2tzL3V0aWwvUHVibGlzaGVyJztcbmltcG9ydCAnLi9saWIvbG9hZC1kb2pvLWxvYWRlcic7XG4iXX0=

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -4,7 +4,7 @@
         if (v !== undefined) module.exports = v;
     }
     else if (typeof define === "function" && define.amd) {
-        define(["require", "exports", "./tasks/fixSourceMaps", "./tasks/installPeerDependencies", "./tasks/link", "./tasks/release", "./tasks/rename", "./tasks/repl", "./tasks/run", "./tasks/ts", "./tasks/typedoc", "./tasks/uploadCoverage", "./tasks/util/Publisher", "./lib/load-dojo-loader"], factory);
+        define(["require", "exports", "./tasks/fixSourceMaps", "./tasks/installPeerDependencies", "./tasks/link", "./tasks/release", "./tasks/rename", "./tasks/repl", "./tasks/run", "./tasks/ts", "./tasks/typedoc", "./tasks/uploadCoverage", "./tasks/util/exec", "./tasks/util/Publisher", "./lib/load-dojo-loader"], factory);
     }
 })(function (require, exports) {
     "use strict";
@@ -19,7 +19,8 @@
     require("./tasks/ts");
     require("./tasks/typedoc");
     require("./tasks/uploadCoverage");
+    require("./tasks/util/exec");
     require("./tasks/util/Publisher");
     require("./lib/load-dojo-loader");
 });
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYWxsLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiYWxsLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7Ozs7Ozs7O0lBQUEsaUNBQStCO0lBQy9CLDJDQUF5QztJQUN6Qyx3QkFBc0I7SUFDdEIsMkJBQXlCO0lBQ3pCLDBCQUF3QjtJQUN4Qix3QkFBc0I7SUFDdEIsdUJBQXFCO0lBQ3JCLHNCQUFvQjtJQUNwQiwyQkFBeUI7SUFDekIsa0NBQWdDO0lBQ2hDLGtDQUFnQztJQUNoQyxrQ0FBZ0MiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgJy4vdGFza3MvZml4U291cmNlTWFwcyc7XG5pbXBvcnQgJy4vdGFza3MvaW5zdGFsbFBlZXJEZXBlbmRlbmNpZXMnO1xuaW1wb3J0ICcuL3Rhc2tzL2xpbmsnO1xuaW1wb3J0ICcuL3Rhc2tzL3JlbGVhc2UnO1xuaW1wb3J0ICcuL3Rhc2tzL3JlbmFtZSc7XG5pbXBvcnQgJy4vdGFza3MvcmVwbCc7XG5pbXBvcnQgJy4vdGFza3MvcnVuJztcbmltcG9ydCAnLi90YXNrcy90cyc7XG5pbXBvcnQgJy4vdGFza3MvdHlwZWRvYyc7XG5pbXBvcnQgJy4vdGFza3MvdXBsb2FkQ292ZXJhZ2UnO1xuaW1wb3J0ICcuL3Rhc2tzL3V0aWwvUHVibGlzaGVyJztcbmltcG9ydCAnLi9saWIvbG9hZC1kb2pvLWxvYWRlcic7XG4iXX0=
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYWxsLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiYWxsLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7Ozs7Ozs7O0lBQUEsaUNBQStCO0lBQy9CLDJDQUF5QztJQUN6Qyx3QkFBc0I7SUFDdEIsMkJBQXlCO0lBQ3pCLDBCQUF3QjtJQUN4Qix3QkFBc0I7SUFDdEIsdUJBQXFCO0lBQ3JCLHNCQUFvQjtJQUNwQiwyQkFBeUI7SUFDekIsa0NBQWdDO0lBQ2hDLDZCQUEyQjtJQUMzQixrQ0FBZ0M7SUFDaEMsa0NBQWdDIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0ICcuL3Rhc2tzL2ZpeFNvdXJjZU1hcHMnO1xuaW1wb3J0ICcuL3Rhc2tzL2luc3RhbGxQZWVyRGVwZW5kZW5jaWVzJztcbmltcG9ydCAnLi90YXNrcy9saW5rJztcbmltcG9ydCAnLi90YXNrcy9yZWxlYXNlJztcbmltcG9ydCAnLi90YXNrcy9yZW5hbWUnO1xuaW1wb3J0ICcuL3Rhc2tzL3JlcGwnO1xuaW1wb3J0ICcuL3Rhc2tzL3J1bic7XG5pbXBvcnQgJy4vdGFza3MvdHMnO1xuaW1wb3J0ICcuL3Rhc2tzL3R5cGVkb2MnO1xuaW1wb3J0ICcuL3Rhc2tzL3VwbG9hZENvdmVyYWdlJztcbmltcG9ydCAnLi90YXNrcy91dGlsL2V4ZWMnO1xuaW1wb3J0ICcuL3Rhc2tzL3V0aWwvUHVibGlzaGVyJztcbmltcG9ydCAnLi9saWIvbG9hZC1kb2pvLWxvYWRlcic7XG4iXX0=

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,0 +1,12 @@
+import './tasks/fixSourceMaps';
+import './tasks/installPeerDependencies';
+import './tasks/link';
+import './tasks/release';
+import './tasks/rename';
+import './tasks/repl';
+import './tasks/run';
+import './tasks/ts';
+import './tasks/typedoc';
+import './tasks/uploadCoverage';
+import './tasks/util/Publisher';
+import './lib/load-dojo-loader';

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -8,5 +8,6 @@ import './tasks/run';
 import './tasks/ts';
 import './tasks/typedoc';
 import './tasks/uploadCoverage';
+import './tasks/util/exec';
 import './tasks/util/Publisher';
 import './lib/load-dojo-loader';

--- a/tests/unit/tasks/typedoc.ts
+++ b/tests/unit/tasks/typedoc.ts
@@ -26,6 +26,7 @@ let expandMapping: SinonStub;
 let execSync: SinonSpy;
 let cp: SinonSpy;
 let rm: SinonSpy;
+let touch: SinonSpy;
 let shouldPush: SinonSpy;
 let shouldPushValue: boolean;
 let failInitialCheckout: boolean;
@@ -42,6 +43,7 @@ registerSuite({
 	setup() {
 		cp = spy(() => {});
 		rm = spy(() => {});
+		touch = spy(() => {});
 		execSync = spy((command: string) => {
 			if (/git checkout/.test(command) && failInitialCheckout) {
 				failInitialCheckout = false;
@@ -59,7 +61,8 @@ registerSuite({
 			'shelljs': {
 				config: {},
 				cp,
-				rm
+				rm,
+				touch
 			},
 			'./util/exec': {
 				'default': execSync

--- a/tests/unit/tasks/typedoc.ts
+++ b/tests/unit/tasks/typedoc.ts
@@ -162,8 +162,8 @@ registerSuite({
 		test() {
 			runGruntTask('typedoc');
 			assert.isTrue(publisherConstructor.calledOnce);
-			assert.isFalse(publisher.skipPublish);
-			assert.isDefined(publisher.log);
+			assert.isFalse(publisherConstructor.firstCall.args[2].skipPublish);
+			assert.isDefined(publisherConstructor.firstCall.args[2].log);
 			assert.isTrue(publisher.publish.calledOnce);
 		}
 	},
@@ -180,8 +180,8 @@ registerSuite({
 		test() {
 			runGruntTask('typedoc');
 			assert.isTrue(publisherConstructor.calledOnce);
-			assert.isTrue(publisher.skipPublish);
-			assert.isDefined(publisher.log);
+			assert.isTrue(publisherConstructor.firstCall.args[2].skipPublish);
+			assert.isDefined(publisherConstructor.firstCall.args[2].log);
 			assert.isTrue(publisher.publish.calledOnce);
 		}
 	}

--- a/tests/unit/tasks/util/Publisher.ts
+++ b/tests/unit/tasks/util/Publisher.ts
@@ -1,0 +1,183 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { SinonStub, stub, spy } from 'sinon';
+import { Options, default as PublisherInstance } from 'grunt-dojo2/tasks/util/Publisher';
+import { unloadTasks, loadModule } from 'grunt-dojo2/tests/unit/util';
+
+const cloneDir = '_tests/cloneDir';
+const generatedDocsDir = '_tests/generatedDocsDir';
+const cpStub: SinonStub = stub();
+const rmStub: SinonStub = stub();
+const execStub: SinonStub = stub();
+let Publisher: typeof PublisherInstance;
+
+function assertCommit() {
+	assert.isTrue(execStub.called);
+	assert.isTrue(rmStub.called);
+	assert.isTrue(cpStub.called);
+}
+registerSuite({
+	name: 'tasks/util/Publisher',
+
+	setup() {
+		const mocks = {
+			'shelljs': {
+				config: {},
+				cp: cpStub,
+				rm: rmStub
+			},
+			'./exec': {
+				'default': execStub
+			}
+		};
+		Publisher = loadModule('grunt-dojo2/tasks/util/Publisher', mocks);
+	},
+
+	beforeEach() {
+		cpStub.reset();
+		execStub.reset();
+		rmStub.reset();
+	},
+
+	teardown() {
+		unloadTasks();
+	},
+
+	construct: {
+		'no overrides'() {
+			const publisher = new Publisher(cloneDir, generatedDocsDir);
+
+			assert.strictEqual(publisher.cloneDir, cloneDir);
+			assert.strictEqual(publisher.encryptedDeployKey, false);
+			assert.isUndefined(publisher.deployKeyTag);
+			assert.strictEqual(publisher.generatedDocsDirectory, generatedDocsDir);
+			assert.strictEqual(publisher.subDirectory, 'api');
+			assert.strictEqual(publisher.branch, 'gh-pages');
+			assert.strictEqual(publisher.shouldPush, Publisher.prototype.shouldPush);
+			assert.isFalse(publisher.skipPublish);
+		},
+
+		'with overrides'() {
+			const overrides: Options = {
+				branch: 'branch',
+				deployKeyTag: 'deployKeyTag',
+				encryptedDeployKey: 'encrypted',
+				shouldPush: () => false,
+				subDirectory: 'subDirectory'
+			};
+			const publisher = new Publisher(cloneDir, generatedDocsDir, overrides);
+
+			assert.strictEqual(publisher.cloneDir, cloneDir);
+			assert.strictEqual(publisher.encryptedDeployKey, overrides.encryptedDeployKey);
+			assert.strictEqual(publisher.deployKeyTag, overrides.deployKeyTag);
+			assert.strictEqual(publisher.generatedDocsDirectory, generatedDocsDir);
+			assert.strictEqual(publisher.subDirectory, overrides.subDirectory);
+			assert.strictEqual(publisher.branch, overrides.branch);
+			assert.strictEqual(publisher.shouldPush, overrides.shouldPush);
+			assert.isFalse(publisher.skipPublish);
+		}
+	},
+
+	hasDeployCredentials: {
+		'missing encryptedDeployKey; returns false'() {
+			const publisher = new Publisher(cloneDir, generatedDocsDir, {
+				deployKeyTag: 'key tag'
+			});
+			assert.isFalse(publisher.hasDeployCredentials());
+		},
+
+		'missing deployKeyTag; returns false'() {
+			const publisher = new Publisher(cloneDir, generatedDocsDir, {
+				encryptedDeployKey: 'LICENSE'
+			});
+			assert.isFalse(publisher.hasDeployCredentials());
+		},
+
+		'missing keyFile; returns false'() {
+			const publisher = new Publisher(cloneDir, generatedDocsDir, {
+				deployKeyTag: 'key tag',
+				encryptedDeployKey: 'does-not-exist'
+			});
+			assert.isFalse(publisher.hasDeployCredentials());
+		},
+
+		'keyFile present; returns true'() {
+			const publisher = new Publisher(cloneDir, generatedDocsDir, {
+				deployKeyTag: 'key tag',
+				encryptedDeployKey: 'LICENSE'
+			});
+			assert.isTrue(publisher.hasDeployCredentials());
+		}
+	},
+
+	publish: {
+		'skipPublish; commit only'() {
+			const publisher = new Publisher(cloneDir, generatedDocsDir);
+			const log = publisher.log = { writeln: stub() };
+			const decryptDeployKey = spy(publisher, 'decryptDeployKey');
+			publisher.skipPublish = true;
+			publisher.publish();
+
+			assertCommit();
+			assert.isFalse(decryptDeployKey.called);
+			assert.strictEqual(log.writeln.lastCall.args[0], 'Only committing -- skipping push to repo');
+		},
+
+		'shouldPush false; commit only'() {
+			const publisher = new Publisher(cloneDir, generatedDocsDir, {
+				shouldPush() { return false; }
+			});
+			const log = publisher.log = { writeln: stub() };
+			const decryptDeployKey = spy(publisher, 'decryptDeployKey');
+			publisher.publish();
+
+			assertCommit();
+			assert.isFalse(decryptDeployKey.called);
+			assert.strictEqual(log.writeln.lastCall.args[0], 'Only committing -- skipping push to repo');
+		},
+
+		'canPublish false; logs error'() {
+			const publisher = new Publisher(cloneDir, generatedDocsDir, {
+				shouldPush() { return true; }
+			});
+			const decryptDeployKey = spy(publisher, 'decryptDeployKey');
+			const canPublish = stub(publisher, 'canPublish');
+			const log = publisher.log = { writeln: stub() };
+			canPublish.returns(false);
+			publisher.publish();
+
+			assertCommit();
+			assert.isTrue(decryptDeployKey.called);
+			assert.strictEqual(log.writeln.lastCall.args[0], 'Push check failed -- not publishing API docs');
+		},
+
+		'working case'() {
+			const publisher = new Publisher(cloneDir, generatedDocsDir, {
+				shouldPush() { return true; }
+			});
+			const decryptDeployKey = spy(publisher, 'decryptDeployKey');
+			const canPublish = stub(publisher, 'canPublish');
+			const log = publisher.log = { writeln: stub() };
+			canPublish.returns(true);
+			publisher.publish();
+
+			assertCommit();
+			assert.isTrue(decryptDeployKey.called);
+			assert.strictEqual(log.writeln.lastCall.args[0], 'Pushed gh-pages to origin');
+		}
+	},
+
+	shouldPush: {
+		'not master; returns false'() {
+			execStub.returns('branch');
+			const publisher = new Publisher(cloneDir, generatedDocsDir);
+			assert.isFalse(publisher.shouldPush());
+		},
+
+		'branch is master; returns true'() {
+			execStub.returns('master');
+			const publisher = new Publisher(cloneDir, generatedDocsDir);
+			assert.isTrue(publisher.shouldPush());
+		}
+	}
+});

--- a/tests/unit/tasks/util/Publisher.ts
+++ b/tests/unit/tasks/util/Publisher.ts
@@ -3,6 +3,7 @@ import * as assert from 'intern/chai!assert';
 import { SinonStub, stub, spy } from 'sinon';
 import { Options, default as PublisherInstance } from 'grunt-dojo2/tasks/util/Publisher';
 import { unloadTasks, loadModule } from 'grunt-dojo2/tests/unit/util';
+import { existsSync } from 'fs';
 
 const cachedTravisBranchEnv = process.env.TRAVIS_BRANCH;
 const cloneDir = '_tests/cloneDir';
@@ -88,6 +89,11 @@ registerSuite({
 			assert.strictEqual(publisher.subDirectory, overrides.subDirectory);
 			assert.strictEqual(publisher.url, overrides.url);
 			assert.strictEqual(publisher.shouldPush, overrides.shouldPush);
+		},
+
+		'default logger'() {
+			const publisher = new Publisher(cloneDir, generatedDocsDir);
+			publisher.log.writeln('hi');
 		}
 	},
 
@@ -117,6 +123,10 @@ registerSuite({
 	},
 
 	publish: {
+		beforeEach() {
+			existsStub.onFirstCall().returns(false);
+		},
+
 		'skipPublish; commit only'() {
 			const log = { writeln: stub() };
 			const publisher = new Publisher(cloneDir, generatedDocsDir, {
@@ -160,13 +170,13 @@ registerSuite({
 		},
 
 		'working case'() {
+			existsStub.returns(true);
 			const log = { writeln: stub() };
 			const publisher = new Publisher(cloneDir, generatedDocsDir, {
 				log,
-				shouldPush() { return true; }
+				shouldPush() { return true; },
+				deployKey: 'deploy_key'
 			});
-			const canPublish = stub(publisher, 'canPublish');
-			canPublish.returns(true);
 			publisher.publish();
 
 			assertCommit();

--- a/tests/unit/tasks/util/exec.ts
+++ b/tests/unit/tasks/util/exec.ts
@@ -1,0 +1,67 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { stub } from 'sinon';
+import { unloadTasks, loadModule } from 'grunt-dojo2/tests/unit/util';
+
+let exec: any;
+const execStub = stub();
+
+registerSuite({
+	name: 'tasks/util/exec',
+
+	setup() {
+		const mocks = {
+			'child_process': {
+				'execSync': execStub
+			}
+		};
+
+		exec = loadModule('grunt-dojo2/tasks/util/exec', mocks);
+	},
+
+	teardown() {
+		unloadTasks();
+	},
+
+	'default'() {
+		const command = 'cmd';
+		exec(command);
+		assert.strictEqual(execStub.lastCall.args[0], command);
+		const options = execStub.lastCall.args[1];
+		assert.strictEqual(options.encoding, 'utf8');
+		assert.strictEqual(options.stdio, 'inherit');
+	},
+
+	'set encoding'() {
+		const command = 'cmd';
+		exec(command, {
+			encoding: 'pizza'
+		});
+		assert.strictEqual(execStub.lastCall.args[0], command);
+		const options = execStub.lastCall.args[1];
+		assert.strictEqual(options.encoding, 'pizza');
+		assert.strictEqual(options.stdio, 'inherit');
+	},
+
+	'silent true'() {
+		const command = 'cmd';
+		exec(command, {
+			silent: true
+		});
+		assert.strictEqual(execStub.lastCall.args[0], command);
+		const options = execStub.lastCall.args[1];
+		assert.strictEqual(options.encoding, 'utf8');
+		assert.strictEqual(options.stdio, 'pipe');
+	},
+
+	'stdio set'() {
+		const command = 'cmd';
+		exec(command, {
+			stdio: 'pizza'
+		});
+		assert.strictEqual(execStub.lastCall.args[0], command);
+		const options = execStub.lastCall.args[1];
+		assert.strictEqual(options.encoding, 'utf8');
+		assert.strictEqual(options.stdio, 'pizza');
+	}
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"inlineSourceMap": true,
 		"inlineSources": true,
 		"module": "umd",
@@ -8,7 +9,12 @@
 		"pretty": true,
 		"target": "es5",
 		"strictNullChecks": true,
-		"noImplicitThis": true
+		"noImplicitThis": true,
+		"paths": {
+			"grunt-dojo2/*": [
+				"./*"
+			]
+		}
 	},
 	"include": [
 		"./index.ts",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* support publishing of typedocs w/ an encrypted deploy key
* Added documentation to README.md
* cleanup and tests

**Description:**

Resolves #55849 & #55847