### PR TITLE
Update tasks to support new widgets structure

### DIFF
--- a/options/copy.ts
+++ b/options/copy.ts
@@ -12,8 +12,8 @@ export = function (grunt: IGrunt) {
 		},
 		'staticDefinitionFiles-dev': {
 			expand: true,
-			cwd: '.',
-			src: [ path.join('src', '<%= staticDefinitionFiles %>') ],
+			cwd: 'src',
+			src: [ '<%= staticDefinitionFiles %>' ],
 			dest: '<%= devDirectory %>'
 		},
 		'staticDefinitionFiles-dist': {

--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -52,7 +52,7 @@ export = function(grunt: IGrunt) {
 	function moduleFiles(dest: string) {
 		return [{
 			expand: true,
-			src: ['**/*.css', '!**/variables.css', '!styles/widgets.css'],
+			src: ['**/*.css', '!**/variables.css', '!common/styles/widgets.css'],
 			dest: dest,
 			cwd: 'src'
 		}];
@@ -70,9 +70,9 @@ export = function(grunt: IGrunt) {
 			map: true
 		},
 		'modules-dev': {
-			files: moduleFiles(path.join(devDirectory, 'src')),
+			files: moduleFiles(devDirectory),
 			options: {
-				processors: moduleProcessors(devDirectory)
+				processors: moduleProcessors(devDirectory, 'src')
 			}
 		},
 		'modules-dist': {

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -5,7 +5,7 @@ export = function(grunt: IGrunt) {
 	const distDirectory = grunt.config.get<string>('distDirectory');
 	const defaultOptions: any = {
 		dist: {
-			exclude: ['tests/**/*.ts', 'src/examples/**/*.ts'],
+			exclude: ['tests/**/*.ts', 'src/*/tests/**/*.ts', 'src/*/example/**/*.ts'],
 			compilerOptions: {
 				outDir: distDirectory,
 				declaration: true,
@@ -14,7 +14,7 @@ export = function(grunt: IGrunt) {
 			}
 		},
 		esm: {
-			exclude: ['tests/**/*.ts'],
+			exclude: ['tests/**/*.ts', 'src/*/tests/**/*.ts', 'src/*/example/**/*.ts'],
 			compilerOptions: {
 				target: 'es6',
 				module: 'es6',


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR updates the TS task, the PostCSS modules task, and the static definition files copy task to work with the [new widgets structure](https://github.com/dojo/widgets/pull/48). All other projects should be unaffected.

Resolves #100