### PR TITLE
Skip all widgets.css files

### DIFF
--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -52,7 +52,7 @@ export = function(grunt: IGrunt) {
 	function moduleFiles(dest: string) {
 		return [{
 			expand: true,
-			src: ['**/*.css', '!**/variables.css', '!common/styles/widgets.css'],
+			src: ['**/*.css', '!**/variables.css', '!**/widgets.css'],
 			dest: dest,
 			cwd: 'src'
 		}];


### PR DESCRIPTION
**Type:** feature

Change to *all* files names `widgets.css` are skipped, same as how all `variables.css` files are skipped.