### PR TITLE
Provide tslint from grunt-dojo2

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "remap-istanbul": ">=0.6.3",
     "resolve-from": "^2.0.0",
     "shelljs": "^0.7.6",
+    "tslint": "~3.15.1",
     "typedoc": "^0.5.6",
     "umd-wrapper": "^0.1.0"
   },
@@ -72,7 +73,6 @@
     "mockery": "^2.0.0",
     "shx": ">=0.1.2",
     "sinon": "^1.17.6",
-    "tslint": "~3.15.1",
     "typescript": "~2.2.1",
     "typings": "^1.3.1"
   }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

In order to move to tslint 4.0+ without breaking downstream projects `grunt-dojo2` needs to provide the `tslint` dependency.

Once released all packages can remove their dev dependency on `tslint`.

Related to https://github.com/dojo/meta/issues/159