### PR TITLE
Renaming CSS modules to .m.css, widgets-76

### DIFF
--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -30,7 +30,7 @@ export = function init(grunt: IGrunt) {
 		}];
 	}
 
-	const variableFiles = [{
+	const cssFiles = [{
 		expand: true,
 		src: ['**/*.css', '!**/*.m.css'],
 		dest: distDirectory,
@@ -54,7 +54,7 @@ export = function init(grunt: IGrunt) {
 			}
 		},
 		variables: {
-			files: variableFiles,
+			files: cssFiles,
 			options: {
 				processors: variablesProcessors
 			}

--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -26,7 +26,7 @@ export = function init(grunt: IGrunt) {
 	function moduleFiles(dest: string) {
 		return [{
 			expand: true,
-			src: ['**/*.css', '!**/variables.css', '!**/widgets.css'],
+			src: ['**/*.m.css'],
 			dest: dest,
 			cwd: 'src'
 		}];
@@ -34,7 +34,7 @@ export = function init(grunt: IGrunt) {
 
 	const variableFiles = [{
 		expand: true,
-		src: '**/variables.css',
+		src: ['**/*.css', '!**/*.m.css'],
 		dest: distDirectory,
 		cwd: 'src'
 	}];

--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -32,7 +32,7 @@ export = function init(grunt: IGrunt) {
 
 	const variableFiles = [{
 		expand: true,
-		src: ['**/variables.css'],
+		src: ['**/*.css', '!**/*.m.css'],
 		dest: distDirectory,
 		cwd: 'src'
 	}];

--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -5,8 +5,6 @@ export = function init(grunt: IGrunt) {
 	const fs = require('fs');
 	const postCssImport = require('postcss-import');
 	const postCssNext = require('postcss-cssnext');
-	const postCssModules = require('postcss-modules');
-	const umdWrapper = require('./util/umdWrapper');
 	grunt.loadNpmTasks('grunt-postcss');
 
 	const distDirectory = grunt.config.get<string>('distDirectory') || '';
@@ -34,7 +32,7 @@ export = function init(grunt: IGrunt) {
 
 	const variableFiles = [{
 		expand: true,
-		src: ['**/*.css', '!**/*.m.css'],
+		src: ['**/variables.css'],
 		dest: distDirectory,
 		cwd: 'src'
 	}];


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Renaming CSS module files to `.m.css`. Regular `.css` files are all run through the variable processor now, and not just `variables.css`.

Resolves https://github.com/dojo/widgets/issues/76
