### PR TITLE
Pinning typedoc to known working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "resolve-from": "^2.0.0",
     "shelljs": "^0.7.6",
     "tslint": "^4.5.1",
-    "typedoc": "^0.5.6",
+    "typedoc": "0.5.7",
     "umd-wrapper": "^0.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "resolve-from": "^2.0.0",
     "shelljs": "^0.7.6",
     "tslint": "^4.5.1",
-    "typedoc": "0.5.7",
+    "typedoc": "0.5.9",
     "umd-wrapper": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**Type:** feature

**Description:**

Pinning TypeDoc to a known version (`0.5.7`).
