### PR TITLE
Pinning @types/lodash because 4.14.57 causes the build to fail...

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/es6-shim": "^0.31.32",
     "@types/glob": "^5.0.30",
     "@types/grunt": "~0.4.20",
-    "@types/lodash": "^4.14.40",
+    "@types/lodash": "4.14.56",
     "@types/mockery": "~1.4.29",
     "@types/node": "^7.0.0",
     "@types/sinon": "~1.16.32",


### PR DESCRIPTION
Fresh `npm install` on master fails right now because of a build error with `@types/lodash` v`4.14.57`. Pinning back to `4.14.56` seems to fix the error.