### PR TITLE
Remove overwrite of main and typings on release

### DIFF
--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -51,8 +51,6 @@ export = function(grunt: IGrunt, packageJson: any) {
 		packageJson.private = undefined;
 		packageJson.scripts = undefined;
 		packageJson.files = undefined;
-		packageJson.typings = undefined;
-		packageJson.main = 'main.js';
 		return packageJson;
 	}
 

--- a/tests/unit/tasks/release.ts
+++ b/tests/unit/tasks/release.ts
@@ -577,8 +577,8 @@ registerSuite({
 				assert.isUndefined(newPackageJson.private);
 				assert.isUndefined(newPackageJson.scripts);
 				assert.isUndefined(newPackageJson.files);
-				assert.isUndefined(newPackageJson.typings);
-				assert.equal(newPackageJson.main, 'main.js');
+				assert.equal(newPackageJson.typings, 'index.d.ts');
+				assert.equal(newPackageJson.main, 'index.js');
 
 				assert.isTrue(grunt.file.exists('temp/README.md'));
 			},


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Stop the release task overwriting `main` and `typings` in the target `package.json`.

Resolves #50
