### PR TITLE
Ensure `--tag` option is passed to `npm publish`

### DIFF
--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -135,10 +135,10 @@ export = function(grunt: IGrunt, packageJson: any) {
 	grunt.registerTask('release-publish', 'publish the package to npm', function (this: ITask) {
 		const done = this.async();
 		const args = ['publish', '.'];
-		const promises = [command(npmBin, args, { cwd: temp }, false)];
 		if (tag) {
 			args.push('--tag', tag);
 		}
+		const promises = [command(npmBin, args, { cwd: temp }, false)];
 		grunt.log.subhead('publishing to npm...');
 		if (dryRun) {
 			promises.push(command(npmBin, ['pack', '../' + temp], { cwd: 'dist' }, true));

--- a/tests/unit/tasks/release.ts
+++ b/tests/unit/tasks/release.ts
@@ -229,6 +229,7 @@ registerSuite({
 
 			runGruntTask('release-publish', dfd.callback(() => {
 				assert.isTrue(shell.calledOnce);
+				assert.isTrue(shell.calledWith('npm publish .'));
 			})).catch(dfd.rejectOnError(() => {
 				assert(false, 'should have succeeded');
 			}));
@@ -246,6 +247,7 @@ registerSuite({
 
 			runGruntTask('release-publish', dfd.callback(() => {
 				assert.isTrue(shell.calledOnce);
+				assert.isTrue(shell.calledWith('npm publish . --tag test'));
 			})).catch(dfd.rejectOnError(() => {
 				assert(false, 'should have succeeded');
 			}));


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure `--tag` option is passed to `npm publish`

Resolves #129 
