### PR TITLE
Add '--no-save' flag to ensure npm5 does not write to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,13 +68,13 @@
     "@types/node": "^7.0.0",
     "@types/sinon": "~1.16.32",
     "@types/shelljs": "^0.6.0",
-    "dojo-loader": "^2.0.0-beta.7",
+    "dojo-loader": "latest",
     "grunt": "^1.0.1",
     "intern": "~3.4.1",
     "mockery": "^2.0.0",
     "shx": ">=0.1.2",
     "sinon": "^1.17.6",
-    "typescript": "~2.3.2",
+    "typescript": "~2.4.2",
     "typings": "^1.3.1"
   }
 }

--- a/tasks/installPeerDependencies.ts
+++ b/tasks/installPeerDependencies.ts
@@ -8,7 +8,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 		for (let name in peerDeps) {
 			grunt.log.write(`installing peer dependency ${name} with version ${peerDeps[name]}...`);
 			try {
-				let cmd = `${packageCmd} ${name}@"${peerDeps[name]}"`;
+				let cmd = `${packageCmd} ${name}@"${peerDeps[name]}" --no-save`;
 				exec(cmd, { stdio: 'ignore' });
 				grunt.log.ok('complete.');
 			} catch (error) {

--- a/tests/unit/tasks/installPeerDependencies.ts
+++ b/tests/unit/tasks/installPeerDependencies.ts
@@ -20,8 +20,8 @@ registerSuite({
 			mockShell = stub();
 
 			mockShell
-			.withArgs('npm install my-dep@"1.0"').returns(Promise.resolve({}))
-			.withArgs('npm install error-dep@"1.0"').throws();
+			.withArgs('npm install my-dep@"1.0" --no-save').returns(Promise.resolve({}))
+			.withArgs('npm install error-dep@"1.0" --no-save').throws();
 
 			loadTasks({
 				child_process: {
@@ -38,8 +38,8 @@ registerSuite({
 			runGruntTask('peerDepInstall');
 
 			assert.isTrue(mockShell.calledTwice);
-			assert.isTrue(mockShell.calledWith('npm install my-dep@"1.0"'));
-			assert.isTrue(mockShell.calledWith('npm install error-dep@"1.0"'));
+			assert.isTrue(mockShell.calledWith('npm install my-dep@"1.0" --no-save'));
+			assert.isTrue(mockShell.calledWith('npm install error-dep@"1.0" --no-save'));
 			assert.isTrue(mockLogger.called);
 			assert.isTrue(mockLogger.calledWith('failed.'));
 		}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Use `--no-save` when installing peer dependencies.

Resolves #143 
