### PR TITLE
Adding intern4 support

### DIFF
--- a/options/intern3.ts
+++ b/options/intern3.ts
@@ -16,7 +16,7 @@ export = function (grunt: IGrunt) {
 		remote: {},
 		local: {
 			options: {
-				config: '<%= devDirectory %>/tests/intern-local',
+				config: '<%= devDirectory %>/tests/intern-local'
 			}
 		},
 		node: {

--- a/options/intern4.ts
+++ b/options/intern4.ts
@@ -5,7 +5,7 @@ export = function (grunt: IGrunt) {
 		options: {
 			'reporters': [
 				{ name: 'runner' },
-				{ name: 'jsoncoverage' },
+				{ name: 'lcov', options: { filename: '../coverage-final.lcov' } },
 				{ name: 'htmlcoverage' }
 			]
 		},

--- a/options/intern4.ts
+++ b/options/intern4.ts
@@ -1,0 +1,39 @@
+export = function (grunt: IGrunt) {
+	grunt.loadNpmTasks('intern');
+
+	return {
+		options: {
+			'reporters': [
+				{ name: 'runner' },
+				{ name: 'jsoncoverage' },
+				{ name: 'htmlcoverage' }
+			]
+		},
+		browserstack: {
+			options: {
+				config: '<%= devDirectory %>/tests/intern-browserstack'
+			}
+		},
+		saucelabs: {
+			options: {
+				config: '<%= devDirectory %>/tests/intern-saucelabs'
+			}
+		},
+		node: {
+			options: {
+				config: '<%= devDirectory %>/tests/intern'
+			}
+		},
+		remote: {},
+		local: {
+			options: {
+				config: '<%= devDirectory %>/tests/intern-local'
+			}
+		},
+		proxy: {
+			options: {
+				proxyOnly: true
+			}
+		}
+	};
+};

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "mockery": "^2.0.0",
     "shx": ">=0.1.2",
     "sinon": "^1.17.6",
-    "typescript": "~2.3.2",
+    "typescript": "~2.4.2",
     "typings": "^1.3.1"
   }
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding the ability to opt into intern 4 testing. To use it, modify the project local `Gruntfile` and set the intern version,

```js
module.exports = function (grunt) {
    require('grunt-dojo2').initConfig(grunt, {
        intern: {
            version: 4
        }
    });
};
```

You'll then have to convert the intern config files to use intern 4 configs (uses the same file names, i.e., `intern.ts`, `intern-local.ts`, etc)

Differences:

* No need for `remapIstanbul` task in intern 4.
* w/ intern 4, all coverage data gets output to a `coverage` directory. w/ intern 3, html report was in `html-report` directory.
* No need for the custom reporter w/ intern 4.