### PR TITLE
Update dojo dependencies to the target npm tag during release

### DIFF
--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -167,7 +167,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 				.then(() => {
 					initialPackageJson = packageJson;
 					grunt.log.subhead(`Committing update to ${tag} for @dojo dependencies`);
-					return command(gitBin, ['commit', '-am', 'Update tag for @dojo dependencies'], {}, false);
+					return command(gitBin, [ 'commit', '-am', 'Update tag for @dojo dependencies' ], {}, false);
 				}, () => {
 					grunt.file.write('package.json', JSON.stringify(initialPackageJson, null, '  ') + '\n');
 					grunt.fail.fatal(`${tag} is not available for one or more @dojo dependencies`);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Update dojo dependencies to match the target npm tag of the release command. The command updates the `package.json` and runs `npm install`. If the installation is successful the changes are committed otherwise the release process fails and the version changes are reverted.

Needs tests.

Resolves #140 
