### PR TITLE
Updates for "config" option in Grunt task in Intern 4.0.1

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -79,6 +79,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		staticTestFiles: 'tests/**/*.{html,css,json,xml,js,txt}',
 		staticDefinitionFiles: '**/*.d.ts',
 		devDirectory: '<%= tsconfig.compilerOptions.outDir %>',
+		internConfig: 'intern.json',
 		apiDocDirectory: '_apidoc',
 		apiPubDirectory: '_apipub',
 		distDirectory: 'dist/umd/',
@@ -134,8 +135,6 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		}
 	}
 
-	setCombined(grunt.option<boolean>('combined'));
-
 	grunt.registerTask('test', <any> (function (this: ITask) {
 		const flags = Object.keys(this.flags);
 
@@ -161,15 +160,8 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		});
 
 		grunt.registerTask('intern4', '', () => {
-			// intern 4 doesn't support the config property anymore, so we need to
-			// manually read the config files and inject them into the intern config
-			Object.keys(options['intern4']).forEach(key => {
-				if (options.intern4[key].options) {
-					injectInternConfig(grunt, options.intern4[key].options);
-				}
-			});
-
 			grunt.config('intern', options.intern4);
+
 			flags.forEach((flag) => {
 				grunt.task.run(`intern:${flag}`);
 			});

--- a/options/intern4.ts
+++ b/options/intern4.ts
@@ -27,9 +27,9 @@ export = function (grunt: IGrunt) {
 				config: '<%= internConfig %>@local'
 			}
 		},
-		proxy: {
+		serve: {
 			options: {
-				proxyOnly: true
+				serveOnly: true
 			}
 		}
 	};

--- a/options/intern4.ts
+++ b/options/intern4.ts
@@ -3,6 +3,7 @@ export = function (grunt: IGrunt) {
 
 	return {
 		options: {
+			config: '<%= internConfig %>',
 			'reporters': [
 				{ name: 'runner' },
 				{ name: 'lcov', options: { filename: '../coverage-final.lcov' } },
@@ -11,23 +12,19 @@ export = function (grunt: IGrunt) {
 		},
 		browserstack: {
 			options: {
-				config: '<%= devDirectory %>/tests/intern-browserstack'
+				config: '<%= internConfig %>@browserstack'
 			}
 		},
 		saucelabs: {
 			options: {
-				config: '<%= devDirectory %>/tests/intern-saucelabs'
+				config: '<%= internConfig %>@saucelabs'
 			}
 		},
-		node: {
-			options: {
-				config: '<%= devDirectory %>/tests/intern'
-			}
-		},
+		node: {},
 		remote: {},
 		local: {
 			options: {
-				config: '<%= devDirectory %>/tests/intern-local'
+				config: '<%= internConfig %>@local'
 			}
 		},
 		proxy: {


### PR DESCRIPTION
The grunt task in 4.0.1 was updated to take a `config` property to load the intern config the same way the `intern` command line script does. This change updates the `test` task and `intern4` options to pass the proper options.

Fixes #141 