### PR TITLE
Fixes for intern task errors

### DIFF
--- a/options/intern4.ts
+++ b/options/intern4.ts
@@ -1,11 +1,13 @@
 export = function (grunt: IGrunt) {
 	grunt.loadNpmTasks('intern');
 
+	const progress = grunt.option<boolean>('progress');
+
 	return {
 		options: {
 			config: '<%= internConfig %>',
 			'reporters': [
-				{ name: 'runner' },
+				{ name: 'runner', options: { 'hideSkipped': !progress, 'hidePassed': !progress } },
 				{ name: 'lcov', options: { directory: '.', filename: 'coverage-final.lcov' } },
 				{ name: 'htmlcoverage', options: { directory: 'html-report' } }
 			]


### PR DESCRIPTION
* Copy version-specific properties before setting up any other tasks or options
* Simplify `test` task
* By default for Intern 4, only show errors during test runs
* Added `--progress` option for Intern 4 to show passing and skipped tests

Resolves #160