### PR TITLE
Add tcm task

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		'typings:dev',
 		'tslint',
 		'clean:dev',
+		'tcm',
 		'copy:staticDefinitionFiles-dev',
 		'dojo-ts:dev',
 		'copy:staticTestFiles'
@@ -39,6 +40,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		'typings:dist',
 		'tslint',
 		'clean:dist',
+		'tcm',
 		'copy:staticDefinitionFiles-dist',
 		'dojo-ts:dist',
 		'fixSourceMaps'

--- a/index.ts
+++ b/index.ts
@@ -93,6 +93,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	require('./tasks/repl')(grunt, packageJson);
 	require('./tasks/run')(grunt, packageJson);
 	require('./tasks/release')(grunt, packageJson);
+	require('./tasks/tcm')(grunt);
 	require('./tasks/link')(grunt, packageJson);
 	require('./tasks/fixSourceMaps')(grunt, packageJson);
 	require('./tasks/postcss')(grunt);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "codecov.io": ">=0.1.6",
     "dts-generator": ">=1.7.0",
     "execa": "^0.4.0",
-    "glob": "^7.0.0",
+    "glob": "^7.1.2",
     "grunt-contrib-clean": ">=1.0.0",
     "grunt-contrib-copy": ">=1.0.0",
     "grunt-contrib-watch": ">=1.0.0",
@@ -57,11 +57,12 @@
     "resolve-from": "^2.0.0",
     "shelljs": "^0.7.6",
     "tslint": "^4.5.1",
+    "typed-css-modules": "^0.3.1",
     "typedoc": "0.5.9",
     "umd-wrapper": "^0.1.0"
   },
   "devDependencies": {
-    "@types/glob": "^5.0.30",
+    "@types/glob": "^5.0.33",
     "@types/grunt": "~0.4.20",
     "@types/lodash": "4.14.56",
     "@types/mockery": "~1.4.29",

--- a/tasks/tcm.ts
+++ b/tasks/tcm.ts
@@ -1,0 +1,25 @@
+import * as glob from 'glob';
+import * as DtsCreator from 'typed-css-modules';
+import ITask = grunt.task.ITask;
+export = function(grunt: IGrunt) {
+	grunt.registerTask('tcm', 'generate css modules', function (this: ITask) {
+		const done = this.async();
+		const creator = new DtsCreator({
+			rootDir: process.cwd(),
+			searchDir: 'src',
+		});
+
+		glob('src/**/styles/*.m.css', (error: Error | null, files: string[]) => {
+			if (error) {
+				done(error);
+				return;
+			}
+
+			Promise.all(files.map(file => creator.create(file)))
+				.then(dtsFilesContents => Promise.all(
+					dtsFilesContents.map(dtsFileContents => dtsFileContents.writeFile())
+				))
+				.then(done);
+		});
+	});
+};

--- a/tasks/typed-css-modules.d.ts
+++ b/tasks/typed-css-modules.d.ts
@@ -1,0 +1,26 @@
+declare module 'typed-css-modules' {
+	import typedCssModules = require('typed-css-modules/index');
+
+	export = typedCssModules;
+}
+
+declare module 'typed-css-modules/index' {
+	class DtsContent {
+		writeFile(): Promise<DtsContent>;
+	}
+
+	class DtsCreator {
+		constructor(options?: {
+			rootDir?: string;
+			searchDir?: string;
+			outDir?: string;
+			camelCase?: boolean;
+		});
+
+		create(filePath: string, contents?: string): Promise<DtsContent>;
+	}
+
+	namespace DtsCreator { }
+
+	export = DtsCreator;
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -5,6 +5,7 @@ import './tasks/release';
 import './tasks/rename';
 import './tasks/repl';
 import './tasks/run';
+import './tasks/tcm';
 import './tasks/ts';
 import './tasks/typedoc';
 import './tasks/uploadCoverage';

--- a/tests/unit/tasks/tcm.ts
+++ b/tests/unit/tasks/tcm.ts
@@ -1,0 +1,90 @@
+const { registerSuite } = intern.getInterface('object');
+const { assert } = intern.getPlugin('chai');
+
+import * as grunt from 'grunt';
+import { SinonStub, stub } from 'sinon';
+import { loadTasks, unloadTasks, runGruntTask } from '../util';
+
+let mockGlob: SinonStub;
+let mockCreator: any;
+let mockWriteFile: SinonStub;
+let mockCreate: SinonStub;
+
+registerSuite('tasks/tcm', {
+	afterEach() {
+		mockGlob.reset();
+		mockCreator.reset();
+		unloadTasks();
+	},
+	tests: {
+		'npm': {
+			beforeEach() {
+				grunt.initConfig({});
+				mockGlob = stub().callsArgWith(1, null,  [ 'one', 'two', 'three' ]);
+				mockWriteFile = stub().returns(Promise.resolve());
+				mockCreate = stub().returns(Promise.resolve({
+					writeFile: mockWriteFile
+				}));
+				mockCreator = stub().returns({
+					create: mockCreate
+				});
+			},
+			tests: {
+				'should generate typings for css modules'() {
+					const deferred = this.async();
+					loadTasks({
+						glob: mockGlob,
+						'typed-css-modules': mockCreator
+					});
+					runGruntTask('tcm', deferred.callback(() => {
+						assert.isTrue(mockGlob.calledOnce);
+						assert.equal(
+							mockGlob.firstCall.args[0],
+							'src/**/styles/*.m.css',
+							'Should have searched for all .m.css files in style directories'
+						);
+						assert.isTrue(mockCreator.calledOnce);
+						assert.deepEqual(mockCreator.firstCall.args,  [ {
+							rootDir: process.cwd(),
+							searchDir: 'src'
+						} ]);
+
+						assert.equal(mockCreate.callCount, 3, 'Should have called create for each file');
+						assert.deepEqual(
+							mockCreate.args,
+							[ [ 'one' ], [ 'two' ], [ 'three' ] ],
+							'Should have called create for each file'
+						);
+						assert.equal(mockWriteFile.callCount, 3, 'Should have called writeFile for each file');
+					}));
+				},
+
+				'should fail if there is an error'() {
+					const deferred = this.async();
+					mockGlob.callsArgWith(1, 'error', []);
+					loadTasks({
+						glob: mockGlob,
+						'typed-css-modules': mockCreator
+					});
+					runGruntTask('tcm', deferred.callback((error: any) => {
+						assert.isTrue(mockGlob.calledOnce);
+						assert.equal(
+							mockGlob.firstCall.args[0],
+							'src/**/styles/*.m.css',
+							'Should have searched for all .m.css files in style directories'
+						);
+						assert.isTrue(mockCreator.calledOnce);
+						assert.deepEqual(mockCreator.firstCall.args,  [ {
+							rootDir: process.cwd(),
+							searchDir: 'src'
+						} ]);
+
+						assert.isFalse(mockCreate.called, 'Should not have called create when there was an error');
+						assert.isFalse(mockWriteFile.called, 'Should not have called write file when there was an error');
+						assert.equal(error, 'error', 'Should have passed returned error to callback');
+					}));
+				}
+			}
+		}
+	}
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds a task that generates `.d.ts` files for `.m.css` files in `style` directories before running `tsc`.
Resolves dojo/widgets#307
