### PR TITLE
Add css nano to post css processors

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "typings": "index.d.ts",
   "dependencies": {
     "codecov.io": ">=0.1.6",
+    "cssnano": "^3.10.0",
     "dts-generator": ">=1.7.0",
     "execa": "^0.4.0",
     "glob": "^7.0.0",

--- a/tasks/util/postcss.ts
+++ b/tasks/util/postcss.ts
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs');
+const cssNano = require('cssnano');
 const postCssImport = require('postcss-import');
 const postCssNext = require('postcss-cssnext');
 const postCssModules = require('postcss-modules');
@@ -27,6 +28,8 @@ export function createProcessors(dest: string, cwd = '', dist?: boolean) {
 				json[themeKey] = 'dojo-' + path.basename(outputPath, '.m.css');
 				fs.writeFileSync(newFilePath, umdWrapper(JSON.stringify(json)));
 			}
-		})
+		}),
+		// autoprefixer included in cssnext
+		cssNano({ autoprefixer: false })
 	];
 };

--- a/tests/unit/tasks/util/postcss.ts
+++ b/tests/unit/tasks/util/postcss.ts
@@ -5,6 +5,7 @@ import { stub } from 'sinon';
 import { unloadTasks, loadModule } from '../../util';
 
 let postCssUtil: any;
+const cssNanoModuleStub = stub();
 const postCssModulesStub = stub();
 const postCssImportStub = stub();
 const postCssNextStub = stub();
@@ -18,6 +19,7 @@ registerSuite('tasks/util/postcss', {
 
 	before() {
 		const mocks = {
+			'cssnano': cssNanoModuleStub,
 			'postcss-modules': postCssModulesStub,
 			'postcss-import': postCssImportStub,
 			'postcss-cssnext': postCssNextStub,
@@ -36,6 +38,7 @@ registerSuite('tasks/util/postcss', {
 	},
 
 	beforeEach() {
+		cssNanoModuleStub.reset();
 		postCssModulesStub.reset();
 		postCssImportStub.reset();
 		postCssNextStub.reset();
@@ -53,12 +56,14 @@ registerSuite('tasks/util/postcss', {
 	tests: {
 		createProcessors: {
 			'order'() {
-				const processors = postCssUtil.createProcessors('', '');
-				assert.isTrue(processors.length === 3);
+				const processors = postCssUtil.createProcessors('');
+				assert.isTrue(processors.length === 4);
 				assert.equal(processors[0], postCssImportStub);
 				assert.isTrue(postCssNextStub.calledOnce);
 				assert.isTrue(postCssModulesStub.calledOnce);
+				assert.isTrue(cssNanoModuleStub.calledOnce);
 				assert.isTrue(postCssNextStub.calledBefore(postCssModulesStub));
+				assert.isTrue(postCssModulesStub.calledBefore(cssNanoModuleStub));
 			},
 			'auto prefixer browsers'() {
 				postCssUtil.createProcessors('', '');
@@ -72,6 +77,10 @@ registerSuite('tasks/util/postcss', {
 							]
 						}
 					}
+				}));
+				assert.isTrue(cssNanoModuleStub.calledOnce);
+				assert.isTrue(cssNanoModuleStub.calledWithMatch({
+					autoprefixer: false
 				}));
 			},
 			'generate scoped name': {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This adds cssnano to the post-css processors used for the dev and dist builds, per #96. That ticket seems to indicate that postcss-import should be removed from the dev build. Doing so breaks the build because the variables used in many files that are imported from other files can no longer be resolved. I'm not sure if there was some more context behind the original issue on why we wanted to remove postcss-import or what the alternative would be for a dev build.

Resolves #96
