### PR TITLE
Updating intern loader to accept options

### DIFF
--- a/lib/intern/internLoader.ts
+++ b/lib/intern/internLoader.ts
@@ -4,11 +4,13 @@ intern.registerLoader((options) => {
 	return intern.loadScript('node_modules/@dojo/loader/loader.js')
 		.then(() => intern.loadScript('node_modules/@dojo/shim/util/amd.js'))
 		.then(() => {
+			const { packages = [], baseUrl = intern.config.basePath } = options;
+			packages.push({ 'name': 'sinon', 'location': 'node_modules/sinon/pkg', 'main': 'sinon' });
+
 			(<any> require).config(shimAmdDependencies({
-				baseUrl: options.baseUrl || intern.config.basePath,
-				packages: [
-					{'name': 'sinon', 'location': 'node_modules/sinon/pkg', 'main': 'sinon'}
-				]
+				baseUrl,
+				...options,
+				packages
 			}));
 
 			// load @dojo/shim/main to import the ts helpers


### PR DESCRIPTION
Updating the intern helper to accept options.  Packages can then specify their own config with,

```json
{
    "browser": {
        "loader": {
            "script": "./node_modules/grunt-dojo2/lib/intern/internLoader.js",
            "options": {
                "packages": [
                    { "name": "my-package", "location": "my-location" }
                ]
            }
        }
    }
}
```

Note that we need to specify the `browser.loader.script` manually as intern does not allow us to specify the loader options without the loader.