### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ src: {
 }
 ```
 
-#### grunt ts
+#### grunt dojo-ts
 
-The `grunt ts` task runs a project through the TypeScript compiler using the project's `tsconfig.json`. It is preconfigured with two targets, `dev` and `dist`. 
+The `grunt dojo-ts` task runs a project through the TypeScript compiler using the project's `tsconfig.json`. It is preconfigured with two targets, `dev` and `dist`. 
 
 ##### dev
 
@@ -144,7 +144,7 @@ It is possible to create custom targets for the `ts` by adding an entry to the g
 }
 ```
 
-The custom ts config can be run using `grunt ts:custom`.
+The custom ts config can be run using `grunt grunt-ts:custom`.
 
 #### grunt intern
 


### PR DESCRIPTION
A simple update to the readme to change "grunt ts" to "grunt dojo-ts".

**Note for reviewer...**

The `dojo-ts` task is still looking for `config.ts` for configuration options.  If I want a custom configuration, I can do something like this:

```javascript
{
	ts: {
		custom: {
			exclude: [
				'./devResourses',
				"./tests/**/*.ts"
			]
		}
}
```
To use my custom config, I run `grunt dojo-ts:custom` and that works great.  But if I come into a project and I see that config, I might think I should run `grunt ts:custom` and with the way grunt works, that command succeeds:
```
$ grunt ts:custom
Running "ts:custom" (ts) task

Done.
```
It succeeds but doesn't actually do anything.  Should we consider changing the config property from `ts` to `dojo-ts`?

Resolves #102 
