### PR TITLE
Remove code setting browser loader in-lieu of packages adding it themselves

### DIFF
--- a/options/intern.ts
+++ b/options/intern.ts
@@ -1,14 +1,9 @@
 import * as path from 'path';
-import { parseJson } from 'intern/lib/common/util';
 
 export = function (grunt: IGrunt) {
 	grunt.loadNpmTasks('intern');
 
 	const progress = grunt.option<boolean>('progress');
-
-	// read the test config and find a loader. if no loader is specified, we need to add ours
-	const internJson = grunt.file.read(path.resolve(grunt.config.get('internConfig')));
-	const { browser: { loader: browserLoader = undefined } = {}, loader } = parseJson(internJson);
 
 	return {
 		options: {
@@ -20,9 +15,6 @@ export = function (grunt: IGrunt) {
 				reporters: [
 					{ name: 'runner', options: { 'hideSkipped': !progress, 'hidePassed': !progress } }
 				]
-			},
-			browser: (loader || browserLoader) ? {} : {
-				loader: './node_modules/grunt-dojo2/lib/intern/internLoader.js'
 			}
 		},
 		browserstack: {

--- a/tests/unit/options/intern.ts
+++ b/tests/unit/options/intern.ts
@@ -17,61 +17,94 @@ registerSuite('options/intern', {
 		delete require.cache[require.resolve('../../../options/intern')];
 	},
 	tests: {
-		'uses loader specified in the intern config root'() {
+		'defaults'() {
 			const config = require('../../../options/intern')({
 				...grunt,
 				loadNpmTasks() {
+				}
+			});
+			assert.deepEqual(config, {
+				options: {
+					config: '<%= internConfig %>',
+					node: {
+						'plugins+': [
+							{ script: 'grunt-dojo2/lib/intern/Reporter.js', useLoader: true }
+						],
+						reporters: [
+							{ name: 'runner', options: { 'hideSkipped': true, 'hidePassed': true } }
+						]
+					}
 				},
-				file: {
-					read() {
-						return '{ "loader": "test" }';
+				browserstack: {
+					options: {
+						config: '<%= internConfig %>@browserstack'
+					}
+				},
+				saucelabs: {
+					options: {
+						config: '<%= internConfig %>@saucelabs'
+					}
+				},
+				node: {},
+				remote: {},
+				local: {
+					options: {
+						config: '<%= internConfig %>@local'
+					}
+				},
+				serve: {
+					options: {
+						serveOnly: true
 					}
 				}
 			});
-
-			assert.isTrue(config.options.browser.loader === undefined);
 		},
-		'uses loader specified in the intern config root containing comments'() {
+		'progress'() {
 			const config = require('../../../options/intern')({
 				...grunt,
 				loadNpmTasks() {
 				},
-				file: {
-					read() {
-						return '{ "loader": "test"/*, "suites": []*/ }';
+				option(name: string) {
+					if (name === 'progress') {
+						return true;
 					}
 				}
 			});
-
-			assert.isTrue(config.options.browser.loader === undefined);
-		},
-		'uses loader specified in the intern browser config'() {
-			const config = require('../../../options/intern')({
-				...grunt,
-				loadNpmTasks() {
+			assert.deepEqual(config, {
+				options: {
+					config: '<%= internConfig %>',
+					node: {
+						'plugins+': [
+							{ script: 'grunt-dojo2/lib/intern/Reporter.js', useLoader: true }
+						],
+						reporters: [
+							{ name: 'runner', options: { 'hideSkipped': false, 'hidePassed': false } }
+						]
+					}
 				},
-				file: {
-					read() {
-						return '{ "browser": { "loader": "test" } }';
+				browserstack: {
+					options: {
+						config: '<%= internConfig %>@browserstack'
 					}
-				}
-			});
-
-			assert.isTrue(config.options.browser.loader === undefined);
-		},
-		'injects loader if its empty'() {
-			const config = require('../../../options/intern')({
-				...grunt,
-				loadNpmTasks() {
 				},
-				file: {
-					read() {
-						return '{}';
+				saucelabs: {
+					options: {
+						config: '<%= internConfig %>@saucelabs'
+					}
+				},
+				node: {},
+				remote: {},
+				local: {
+					options: {
+						config: '<%= internConfig %>@local'
+					}
+				},
+				serve: {
+					options: {
+						serveOnly: true
 					}
 				}
 			});
-
-			assert.isTrue(config.options.browser.loader === './node_modules/grunt-dojo2/lib/intern/internLoader.js');
 		}
 	}
 });


### PR DESCRIPTION
**Type:** enhancement

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Setting the loader in the options should be done in each project's `intern.json` so that running `intern` and `grunt intern` both work.