### PR TITLE
Change tcm task to operate on all css modules under src directory

### DIFF
--- a/tasks/tcm.ts
+++ b/tasks/tcm.ts
@@ -9,7 +9,7 @@ export = function(grunt: IGrunt) {
 			searchDir: 'src',
 		});
 
-		glob('src/**/styles/*.m.css', (error: Error | null, files: string[]) => {
+		glob('src/**/*.m.css', (error: Error | null, files: string[]) => {
 			if (error) {
 				done(error);
 				return;
@@ -19,7 +19,7 @@ export = function(grunt: IGrunt) {
 				.then(dtsFilesContents => Promise.all(
 					dtsFilesContents.map(dtsFileContents => dtsFileContents.writeFile())
 				))
-				.then(done);
+				.then(done, done);
 		});
 	});
 };

--- a/tests/unit/tasks/tcm.ts
+++ b/tests/unit/tasks/tcm.ts
@@ -40,8 +40,8 @@ registerSuite('tasks/tcm', {
 						assert.isTrue(mockGlob.calledOnce);
 						assert.equal(
 							mockGlob.firstCall.args[0],
-							'src/**/styles/*.m.css',
-							'Should have searched for all .m.css files in style directories'
+							'src/**/*.m.css',
+							'Should have searched for all .m.css files in src directory'
 						);
 						assert.isTrue(mockCreator.calledOnce);
 						assert.deepEqual(mockCreator.firstCall.args,  [ {
@@ -70,8 +70,8 @@ registerSuite('tasks/tcm', {
 						assert.isTrue(mockGlob.calledOnce);
 						assert.equal(
 							mockGlob.firstCall.args[0],
-							'src/**/styles/*.m.css',
-							'Should have searched for all .m.css files in style directories'
+							'src/**/*.m.css',
+							'Should have searched for all .m.css files in src directory'
 						);
 						assert.isTrue(mockCreator.calledOnce);
 						assert.deepEqual(mockCreator.firstCall.args,  [ {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

The `tcm` task was only operating on files in `styles` and was ignoring the files in `themes`. This changes the task to operate on all files in `src`.
