### PR TITLE
Adding support for ES modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 - travis_retry npm install typings --global
 - travis_retry npm install
 script:
-- tests/run_ci.sh
+- npm run ci
 notifications:
   slack:
     secure: dBTe5XpEQKQHNHKHxac6YuhUlFaNBf4l/qK+RGuTfJSgwL/MleAwNfgrgz5nOS5mBGXkLMbEx++21GeJDIPevnfwDLvMh+OlU5w3909i3Xa17gN9yo7vi6Q+nrXL0NvOgOdUuExj5dWGpkquUN2yBIIycSWk5806Qxvp+6Q1EtPvR2VPMMnEhH7zjOJQu0HgeXhaBliEtaMEsQSX6ZZv2aZimll9TddBNhwRxAg28VnkeYAu7f4GZ1h/ktQLATfe2wpx76wp7FZ08R/xJZP/RReiXu6PqvlOEgPa4TZBvD/71JMuXxgS6+q2enkwthmMn7380kDFLDbNW4/jB8WTsyKTxMu2smkuufxzQpgr+RnWJE+ULDBmq/woeAUmMXFdVRJU2QXGbIMK61rphoWq9d016KHsQP9zZIF9pUD/oSPSAnFQdD9+HJnOh5qQ/DgJSIDyDN3KMcK5zGPXttMKrByUaJ3Du22WnpsurQqm0E3dj/mFEB3g1BTO4vpKXDVpBSPJzRDUaDY+MbwY5VSj8w0WnUnXSf9ZvUs/sFQrroY17p+XOe1tgWcZ8kaA0LTIATLHYQyJJIGNImcwfY665AL/fbzbRJyP2u4fUekM1PQdQ976OjqLAnnnHBuShe6HRRs2hFLrg3Pk/SHux9GVAeKD73dIixsdY0b7jfiI8ts=

--- a/index.ts
+++ b/index.ts
@@ -73,7 +73,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		internConfig: 'intern.json',
 		apiDocDirectory: '_apidoc',
 		apiPubDirectory: '_apipub',
-		distDirectory: 'dist/umd/',
+		distDirectory: 'dist/all/',
 		otherOptions: otherOptions,
 		devTasks,
 		distTasks,

--- a/lib/load-dojo-loader.ts
+++ b/lib/load-dojo-loader.ts
@@ -10,7 +10,7 @@ export default function loadDojoLoader ({ peerDependencies = {} }: any) {
 
 	for (const name in peerDependencies) {
 		if (/^dojo-/.test(name)) {
-			packages.push({ name, location: join('node_modules', name, 'dist', 'umd') });
+			packages.push({ name, location: join('node_modules', name, 'dist', 'all') });
 		}
 		else if (name === '@reactivex/rxjs') {
 			packages.push({ name: 'rxjs', location: join('node_modules', name, 'dist', 'amd') });

--- a/lib/load-dojo-loader.ts
+++ b/lib/load-dojo-loader.ts
@@ -5,7 +5,7 @@ const resolveFrom = require('resolve-from');
 export default function loadDojoLoader ({ peerDependencies = {} }: any) {
 	const baseUrl = process.cwd();
 	const packages = [
-		{ name: 'src', location: '_build/src' }
+		{ name: 'src', location: join('_build', 'src') }
 	];
 
 	for (const name in peerDependencies) {

--- a/options/clean.ts
+++ b/options/clean.ts
@@ -6,7 +6,7 @@ export = function (grunt: IGrunt) {
 			src: [ 'typings/' ]
 		},
 		dist: {
-			src: [ 'dist/umd/*' ],
+			src: [ '<%= devDirectory %>/*' ],
 			filter: function (path: string) {
 				return grunt.option('remove-links') ? true : !grunt.file.isLink(path);
 			}

--- a/options/rename.ts
+++ b/options/rename.ts
@@ -1,18 +1,14 @@
 export = function (grunt: IGrunt) {
 	require('../tasks/rename')(grunt);
 
+	const distDirectory = grunt.config.get<string>('distDirectory');
+
 	return {
 		sourceMaps: {
 			expand: true,
-			cwd: 'dist/umd',
+			cwd: distDirectory,
 			src: [ '**/*.js.map', '!_debug/**/*.js.map' ],
 			dest: 'dist/umd/_debug/'
-		},
-		sourceMaps_esm: {
-			expand: true,
-			cwd: 'dist/esm',
-			src: [ '**/*.js.map', '!_debug/**/*.js.map' ],
-			dest: 'dist/esm/_debug/'
 		}
 	};
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "tsc",
     "prepublish": "shx rm -rf ./typings && typings install && tsc -p .",
-    "test": "tsc -p . && intern"
+    "test": "tsc -p . && intern",
+    "ci": "rm -rf tmp && tsc -p . && intern config=@ci && cat ./lcov.info | ./node_modules/.bin/codecov"
   },
   "author": "Bryan Forbes <bryan@reigndropsfall.net>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc",
     "prepublish": "shx rm -rf ./typings && typings install && tsc -p .",
-    "test": "tests/run.sh"
+    "test": "tsc -p . && intern"
   },
   "author": "Bryan Forbes <bryan@reigndropsfall.net>",
   "contributors": [

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -37,6 +37,16 @@ export = function (grunt: IGrunt) {
 					grunt.file.expand(['dist/esm/**/*.js.map'])
 						.forEach(file => fs.renameSync(file, file.replace(/\.js\.map$/g, '.mjs.map')));
 
+					// fix the source map comments in the .mjs files
+					grunt.file.expand(['dist/esm/**/*.mjs'])
+						.forEach(file => {
+							let contents = grunt.file.read(file);
+
+							contents = contents.replace(/(\/\/.*sourceMappingURL=.*?)(\.js\.map)/g, '$1.mjs.map');
+
+							grunt.file.write(file, contents);
+						});
+
 					// change the .js files to .mjs files inside the map files
 					grunt.file.expand(['dist/esm/**/*.mjs.map'])
 						.forEach(file => {

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -117,6 +117,16 @@ export = function (grunt: IGrunt) {
 				tasks.push('dojo-ts:umd');
 				// commented out until we are ready to use es modules
 				// tasks.push('dojo-ts:esm');
+
+				// merge dist config into umd and esm
+				const distConfig = grunt.config.get('ts.dist') || {};
+
+				grunt.config.merge({
+					ts: {
+						umd: distConfig,
+						esm: distConfig
+					}
+				});
 			}
 
 			if (target in postTasks) {

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -116,7 +116,7 @@ export = function (grunt: IGrunt) {
 			} else {
 				tasks.push('dojo-ts:umd');
 				// commented out until we are ready to use es modules
-				tasks.push('dojo-ts:esm');
+				// tasks.push('dojo-ts:esm');
 
 				// merge dist config into umd and esm
 				const distConfig = grunt.config.get('ts.dist') || {};

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -2,11 +2,13 @@ import * as _ from 'lodash';
 import * as fs from 'fs';
 import ITask = grunt.task.ITask;
 
+const excludes = ['tests/**/*.ts', 'tests/**/*.tsx', 'src/*/tests/**/*.ts', 'src/*/example/**/*.ts'];
+
 export = function (grunt: IGrunt) {
 	const distDirectory = grunt.config.get<string>('distDirectory');
 	const defaultOptions: any = {
 		umd: {
-			exclude: ['tests/**/*.ts', 'src/*/tests/**/*.ts', 'src/*/example/**/*.ts'],
+			exclude: excludes,
 			compilerOptions: {
 				outDir: 'dist/umd',
 				declaration: true,
@@ -15,9 +17,9 @@ export = function (grunt: IGrunt) {
 			}
 		},
 		esm: {
-			exclude: ['tests/**/*.ts', 'src/*/tests/**/*.ts', 'src/*/example/**/*.ts'],
+			exclude: excludes,
 			compilerOptions: {
-				target: 'es6',
+				target: 'esnext',
 				module: 'esnext',
 				sourceMap: true,
 				outDir: 'dist/esm',

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -1,5 +1,4 @@
 import * as _ from 'lodash';
-import * as path from 'path';
 import * as fs from 'fs';
 import ITask = grunt.task.ITask;
 

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -1,7 +1,10 @@
 import * as _ from 'lodash';
+import * as path from 'path';
+import * as glob from 'glob';
+import * as fs from 'fs';
 import ITask = grunt.task.ITask;
 
-export = function(grunt: IGrunt) {
+export = function (grunt: IGrunt) {
 	const distDirectory = grunt.config.get<string>('distDirectory');
 	const defaultOptions: any = {
 		dist: {
@@ -17,19 +20,45 @@ export = function(grunt: IGrunt) {
 			exclude: ['tests/**/*.ts', 'src/*/tests/**/*.ts', 'src/*/example/**/*.ts'],
 			compilerOptions: {
 				target: 'es6',
-				module: 'es6',
-				sourceMap: false,
+				module: 'esnext',
+				sourceMap: true,
 				outDir: 'dist/esm',
-				inlineSourceMap: true,
 				inlineSources: true
 			}
 		}
+	};
+	const postTasks: any = {
+		esm: [
+			function () {
+				grunt.task.registerTask('rename-mjs', () => {
+					// rename .js files to .mjs files
+					glob.sync(path.join(path.resolve('dist/esm'), '**/*.js'))
+						.forEach(file => fs.renameSync(file, file.replace(/\.js$/g, '.mjs')));
+
+					// rename .js.map files to .mjs.map files
+					glob.sync(path.join(path.resolve('dist/esm'), '**/*.js.map'))
+						.forEach(file => fs.renameSync(file, file.replace(/\.js\.map$/g, '.mjs.map')));
+
+					// change the .js files to .mjs files inside the map files
+					glob.sync(path.join(path.resolve('dist/esm'), '**/*.mjs.map'))
+						.forEach(file => {
+							const json = grunt.file.readJSON(file);
+							if (json.file) {
+								json.file = json.file.replace(/\.js$/g, '.mjs');
+							}
+
+							grunt.file.write(file, JSON.stringify(json));
+						});
+				});
+				return 'rename-mjs';
+			}
+		]
 	};
 
 	grunt.registerTask('dojo-ts', <any> function (this: ITask) {
 		grunt.loadNpmTasks('grunt-ts');
 
-		const flags = this.args && this.args.length ? this.args : [ 'dev' ];
+		const flags = this.args && this.args.length ? this.args : ['dev'];
 		const tsconfig = grunt.config.get<any>('tsconfig');
 		const tsOptions = grunt.config.get<any>('ts') || {};
 		const baseOptions = {
@@ -53,12 +82,19 @@ export = function(grunt: IGrunt) {
 				_.merge(targetTsconfig, targetDefaultOptions, targetTsOptions);
 				tsconfigFileName = `.tsconfig${target}.json`;
 				grunt.file.write(tsconfigFileName, JSON.stringify(targetTsconfig));
-				grunt.config.set(`clean.${target}Tsconfig`, { src: tsconfigFileName});
+				grunt.config.set(`clean.${target}Tsconfig`, { src: tsconfigFileName });
 
 				tasks.push(`clean:${target}Tsconfig`);
 			}
-			grunt.config.set(`ts.${target}`, { tsconfig: { passThrough: true, tsconfig: tsconfigFileName }});
+			grunt.config.set(`ts.${target}`, { tsconfig: { passThrough: true, tsconfig: tsconfigFileName } });
+
+			if (target in postTasks) {
+				postTasks[target].forEach((task: any) => {
+					tasks.push(task());
+				});
+			}
 		});
+
 		grunt.task.run(tasks);
 	});
 };

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -120,7 +120,7 @@ export = function (grunt: IGrunt) {
 				const { compilerOptions: { module: moduleFormat = '' } = {} } = tsconfig;
 				if (moduleFormat !== 'commonjs') {
 					// commented out until we are ready to use es modules
-					// tasks.push('dojo-ts:esm');
+					tasks.push('dojo-ts:esm');
 				}
 
 				// merge dist config into umd and esm

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -9,7 +9,7 @@ export = function (grunt: IGrunt) {
 		umd: {
 			exclude: ['tests/**/*.ts', 'src/*/tests/**/*.ts', 'src/*/example/**/*.ts'],
 			compilerOptions: {
-				outDir: distDirectory,
+				outDir: 'dist/umd',
 				declaration: true,
 				sourceMap: true,
 				inlineSources: true
@@ -55,14 +55,12 @@ export = function (grunt: IGrunt) {
 		dist: [
 			function () {
 				grunt.task.registerTask('merge-dist', () => {
-					grunt.file.mkdir(path.resolve('dist/all'));
-
 					grunt.file.expand(['dist/umd/**/*']).forEach((file: string) => {
-						grunt.file.copy(file, file.replace('dist/umd/', 'dist/all/'));
+						grunt.file.copy(file, file.replace('dist/umd/', distDirectory));
 					});
 
 					grunt.file.expand(['dist/esm/**/*']).forEach((file: string) => {
-						grunt.file.copy(file, file.replace('dist/esm/', 'dist/all/'));
+						grunt.file.copy(file, file.replace('dist/esm/', distDirectory));
 					});
 				});
 

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -115,7 +115,8 @@ export = function (grunt: IGrunt) {
 				grunt.config.set(`ts.${target}`, { tsconfig: { passThrough: true, tsconfig: tsconfigFileName } });
 			} else {
 				tasks.push('dojo-ts:umd');
-				tasks.push('dojo-ts:esm');
+				// commented out until we are ready to use es modules
+				// tasks.push('dojo-ts:esm');
 			}
 
 			if (target in postTasks) {

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -115,8 +115,13 @@ export = function (grunt: IGrunt) {
 				grunt.config.set(`ts.${target}`, { tsconfig: { passThrough: true, tsconfig: tsconfigFileName } });
 			} else {
 				tasks.push('dojo-ts:umd');
-				// commented out until we are ready to use es modules
-				// tasks.push('dojo-ts:esm');
+
+				// only compile esm if we're not using commonjs (cli tools use commonjs)
+				const { compilerOptions: { module: moduleFormat = '' } = {} } = tsconfig;
+				if (moduleFormat !== 'commonjs') {
+					// commented out until we are ready to use es modules
+					// tasks.push('dojo-ts:esm');
+				}
 
 				// merge dist config into umd and esm
 				const distConfig = grunt.config.get('ts.dist') || {};

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -19,7 +19,7 @@ export = function (grunt: IGrunt) {
 		esm: {
 			exclude: excludes,
 			compilerOptions: {
-				target: 'esnext',
+				target: 'es6',
 				module: 'esnext',
 				sourceMap: true,
 				outDir: 'dist/esm',
@@ -116,7 +116,7 @@ export = function (grunt: IGrunt) {
 			} else {
 				tasks.push('dojo-ts:umd');
 				// commented out until we are ready to use es modules
-				// tasks.push('dojo-ts:esm');
+				tasks.push('dojo-ts:esm');
 
 				// merge dist config into umd and esm
 				const distConfig = grunt.config.get('ts.dist') || {};

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -e
-cd "$(dirname $0)/.."
-echo "Building Modules..."
-node_modules/.bin/tsc -p .
-echo "Running intern..."
-node_modules/.bin/intern

--- a/tests/run_ci.sh
+++ b/tests/run_ci.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -e
-cd "$(dirname $0)/.."
-rm -rf tmp
-node_modules/.bin/tsc -p .
-node_modules/.bin/intern config=@ci && cat ./lcov.info | ./node_modules/.bin/codecov

--- a/tests/unit/lib/load-dojo-loader.ts
+++ b/tests/unit/lib/load-dojo-loader.ts
@@ -54,7 +54,7 @@ registerSuite('lib/load-dojo-loader', {
 			assert.deepEqual(configPackages, [
 				{ name: 'src', location: '_build/src' },
 				{ name: 'test', location: 'node_modules/test' },
-				{ name: 'dojo-loader', location: 'node_modules/dojo-loader/dist/umd' },
+				{ name: 'dojo-loader', location: 'node_modules/dojo-loader/dist/all' },
 				{ name: 'rxjs', location: 'node_modules/@reactivex/rxjs/dist/amd' },
 				{ name: 'maquette', location: 'node_modules/maquette/dist' },
 				{ name: 'immutable', location: 'node_modules/immutable/dist' }

--- a/tests/unit/lib/load-dojo-loader.ts
+++ b/tests/unit/lib/load-dojo-loader.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
@@ -52,12 +54,12 @@ registerSuite('lib/load-dojo-loader', {
 
 			assert.equal(configBaseUrl, process.cwd());
 			assert.deepEqual(configPackages, [
-				{ name: 'src', location: '_build/src' },
-				{ name: 'test', location: 'node_modules/test' },
-				{ name: 'dojo-loader', location: 'node_modules/dojo-loader/dist/all' },
-				{ name: 'rxjs', location: 'node_modules/@reactivex/rxjs/dist/amd' },
-				{ name: 'maquette', location: 'node_modules/maquette/dist' },
-				{ name: 'immutable', location: 'node_modules/immutable/dist' }
+				{ name: 'src', location: path.join('_build', 'src') },
+				{ name: 'test', location: path.join('node_modules', 'test') },
+				{ name: 'dojo-loader', location: path.join('node_modules', 'dojo-loader', 'dist', 'all') },
+				{ name: 'rxjs', location: path.join('node_modules', '@reactivex', 'rxjs', 'dist', 'amd') },
+				{ name: 'maquette', location: path.join('node_modules', 'maquette', 'dist') },
+				{ name: 'immutable', location: path.join('node_modules', 'immutable', 'dist') }
 			]);
 
 			assert.equal(result.baseUrl, configBaseUrl);

--- a/tests/unit/tasks/ts.ts
+++ b/tests/unit/tasks/ts.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import * as grunt from 'grunt';
 import * as fs from 'fs';
-import { SinonStub, stub } from 'sinon';
+import { sandbox, SinonSandbox, SinonStub } from 'sinon';
 import {
 	cleanOutputDirectory,
 	getOutputDirectory,
@@ -14,6 +14,7 @@ import {
 } from '../util';
 
 const outputPath = getOutputDirectory();
+let mocks: SinonSandbox;
 let run: SinonStub;
 let loadNpmTasks: SinonStub;
 let write: SinonStub;
@@ -30,24 +31,10 @@ registerSuite('tasks/ts', {
 
 		loadTasks();
 
-		run = stub(grunt.task, 'run');
-		loadNpmTasks = stub(grunt, 'loadNpmTasks');
-		write = stub(grunt.file, 'write');
-		expand = stub(grunt.file, 'expand');
-		rename = stub(fs, 'renameSync');
-		readJSON = stub(grunt.file, 'readJSON');
-		copy = stub(grunt.file, 'copy');
-
 		prepareOutputDirectory();
 	},
 	after() {
-		run.restore();
-		loadNpmTasks.restore();
-		write.restore();
-		expand.restore();
-		rename.restore();
-		readJSON.restore();
-		copy.restore();
+		mocks.restore();
 
 		unloadTasks();
 		cleanOutputDirectory();
@@ -76,12 +63,19 @@ registerSuite('tasks/ts', {
 			}
 		});
 
-		run.reset();
-		write.reset();
-		expand.reset();
-		rename.reset();
-		readJSON.reset();
-		copy.reset();
+		mocks = sandbox.create();
+
+		run = mocks.stub(grunt.task, 'run');
+		loadNpmTasks = mocks.stub(grunt, 'loadNpmTasks');
+		write = mocks.stub(grunt.file, 'write');
+		expand = mocks.stub(grunt.file, 'expand');
+		rename = mocks.stub(fs, 'renameSync');
+		readJSON = mocks.stub(grunt.file, 'readJSON');
+		copy = mocks.stub(grunt.file, 'copy');
+	},
+
+	afterEach() {
+		mocks.restore();
 	},
 
 	tests: {

--- a/tests/unit/tasks/ts.ts
+++ b/tests/unit/tasks/ts.ts
@@ -22,6 +22,7 @@ let expand: SinonStub;
 let rename: SinonStub;
 let readJSON: SinonStub;
 let copy: SinonStub;
+let read: SinonStub;
 
 registerSuite('tasks/ts', {
 	before() {
@@ -72,6 +73,7 @@ registerSuite('tasks/ts', {
 		rename = mocks.stub(fs, 'renameSync');
 		readJSON = mocks.stub(grunt.file, 'readJSON');
 		copy = mocks.stub(grunt.file, 'copy');
+		read = mocks.stub(grunt.file, 'read');
 	},
 
 	afterEach() {
@@ -156,7 +158,11 @@ registerSuite('tasks/ts', {
 
 			expand.onFirstCall().returns(['file.js']);
 			expand.onSecondCall().returns(['file.js.map']);
-			expand.onThirdCall().returns(['file.mjs.map']);
+			expand.onThirdCall().returns(['file.mjs']);
+			expand.onCall(3).returns(['file.mjs.map']);
+
+			read.returns(`some file
+//# sourceMappingURL=RouterInjector.js.map`);
 
 			readJSON.returns({
 				file: 'file.js',
@@ -169,7 +175,10 @@ registerSuite('tasks/ts', {
 			assert.isTrue(rename.calledWith('file.js.map', 'file.mjs.map'));
 			assert.isTrue(write.calledWith('file.mjs.map'));
 
-			assert.deepEqual(JSON.parse(write.args[1][1]), {
+			assert.deepEqual(write.args[1][1], `some file
+//# sourceMappingURL=RouterInjector.mjs.map`);
+
+			assert.deepEqual(JSON.parse(write.args[2][1]), {
 				file: 'file.mjs',
 				key: 'value'
 			});

--- a/tests/unit/tasks/ts.ts
+++ b/tests/unit/tasks/ts.ts
@@ -114,7 +114,7 @@ registerSuite('tasks/ts', {
 			runGruntTask('dojo-ts:dist');
 
 			assert.isTrue(run.calledOnce);
-			assert.deepEqual(run.firstCall.args[ 0 ], [ 'dojo-ts:umd', 'dojo-ts:esm', 'merge-dist' ]);
+			assert.deepEqual(run.firstCall.args[ 0 ], [ 'dojo-ts:umd', 'merge-dist' ]);
 
 			expand.onFirstCall().returns(['dist/umd/file1.js']);
 			expand.onSecondCall().returns(['dist/esm/file1.mjs']);

--- a/tests/unit/tasks/ts.ts
+++ b/tests/unit/tasks/ts.ts
@@ -92,18 +92,8 @@ registerSuite('tasks/ts', {
 		dist() {
 			runGruntTask('dojo-ts:dist');
 
-			assert.deepEqual(grunt.config('ts.dist'), {
-				tsconfig: {
-					passThrough: true,
-					tsconfig: '.tsconfigdist.json'
-				}
-			});
-
 			assert.isTrue(run.calledOnce);
-			assert.deepEqual(run.firstCall.args[ 0 ], [ 'ts:dist', 'clean:distTsconfig' ]);
-
-			assert.isTrue(write.calledOnce);
-			assert.isTrue(write.calledWith('.tsconfigdist.json'));
+			assert.deepEqual(run.firstCall.args[ 0 ], [ 'dojo-ts:umd', 'dojo-ts:esm', 'merge-dist' ]);
 		},
 
 		esm() {
@@ -132,7 +122,7 @@ registerSuite('tasks/ts', {
 			});
 
 			assert.isTrue(run.calledOnce);
-			assert.deepEqual(run.firstCall.args[ 0 ], [ 'ts:esm', 'clean:esmTsconfig' ]);
+			assert.deepEqual(run.firstCall.args[ 0 ], [ 'ts:esm', 'clean:esmTsconfig', 'rename-mjs' ]);
 
 			assert.isTrue(write.calledOnce);
 			assert.isTrue(write.calledWith('.tsconfigesm.json'));

--- a/tests/unit/tasks/typedoc.ts
+++ b/tests/unit/tasks/typedoc.ts
@@ -2,7 +2,7 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import * as grunt from 'grunt';
-import { join } from 'path';
+import { join, sep } from 'path';
 import { SinonSpy, spy, SinonStub, stub } from 'sinon';
 import {
 	loadTasks,
@@ -37,6 +37,10 @@ let publisher: {
 	commit: SinonStub;
 	publish: SinonStub;
 };
+
+function escape(str: string): string {
+	return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
 
 registerSuite('tasks/typedoc', {
 
@@ -148,9 +152,9 @@ registerSuite('tasks/typedoc', {
 			runGruntTask('typedoc');
 			const command = execSync.args[0][0];
 			const matcher = new RegExp(
-				`node "[^"]+/typedoc" --mode "modules" --excludeExternals --excludeNotExported ` +
-				`--tsconfig "${join(outputPath, 'tsconfig.json')}" ` +
-				`--logger "none" --out "${apiDocDirectory}"`);
+				`node "[^"]+${escape(sep)}typedoc" --mode "modules" --excludeExternals --excludeNotExported ` +
+				`--tsconfig "${escape(join(outputPath, 'tsconfig.json'))}" ` +
+				`--logger "none" --out "${escape(apiDocDirectory)}"`);
 			assert.match(command, matcher, 'Unexpected typedoc command line');
 			assert.strictEqual(write.callCount, 0, 'Nothing should have been written');
 			assert.strictEqual(execSync.callCount, 1, 'Unexpected number of exec calls');


### PR DESCRIPTION
Adding support for ES modules. During a `grunt dist` command, UMD format will be compiled as usual but a `dist/esm` folder will now additionally be compiled. This folder will contain `.mjs` and `.mjs.map` files. After both directories are created the two will be merged into a single `dist/all` directory.

Made a few other changes allow the tests to be run from Windows.