### PR TITLE
Prevent cssnano from changing z-index values

### DIFF
--- a/tasks/util/postcss.ts
+++ b/tasks/util/postcss.ts
@@ -30,6 +30,6 @@ export function createProcessors(dest: string, cwd = '', dist?: boolean) {
 			}
 		}),
 		// autoprefixer included in cssnext
-		cssNano({ autoprefixer: false })
+		cssNano({ autoprefixer: false, zindex: false })
 	];
 };


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Cssnano pre-v4 changes z-index values by default, unless `{zindex: false}` is set. This seems dangerous for large projects and frameworks and destroys the `zIndex` organization within @dojo/widgets, so this PR changes the setting to false.

(ref: https://github.com/ben-eb/gulp-cssnano/issues/8)