### PR TITLE
Update the CSS _key name to remove the `dojo-` prefix

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -98,7 +98,7 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	require('./tasks/tcm')(grunt);
 	require('./tasks/link')(grunt, packageJson);
 	require('./tasks/fixSourceMaps')(grunt, packageJson);
-	require('./tasks/postcss')(grunt);
+	require('./tasks/postcss')(grunt, packageJson);
 
 	if (otherOptions) {
 		grunt.config.merge(otherOptions);

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "istanbul-reports": "~1.1.1",
     "lodash": "^4.15.0",
     "parse-git-config": "^0.4.2",
+    "pkg-up": "^2.0.0",
     "pkg-dir": "^1.0.0",
     "postcss-cssnext": "^2.9.0",
     "postcss-import": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "istanbul-reports": "~1.1.1",
     "lodash": "^4.15.0",
     "parse-git-config": "^0.4.2",
-    "pkg-up": "^2.0.0",
     "pkg-dir": "^1.0.0",
     "postcss-cssnext": "^2.9.0",
     "postcss-import": "^9.1.0",

--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -1,6 +1,6 @@
 import { createProcessors } from './util/postcss';
 
-export = function init(grunt: IGrunt) {
+export = function init(grunt: IGrunt, packageJson: any) {
 	const path = require('path');
 	const postCssImport = require('postcss-import');
 	const postCssNext = require('postcss-cssnext');
@@ -43,13 +43,21 @@ export = function init(grunt: IGrunt) {
 		'modules-dev': {
 			files: moduleFiles(path.join(devDirectory, 'src')),
 			options: {
-				processors: createProcessors(devDirectory)
+				processors: createProcessors({
+					packageJson,
+					dest: devDirectory
+				})
 			}
 		},
 		'modules-dist': {
 			files: moduleFiles(distDirectory),
 			options: {
-				processors: createProcessors(distDirectory, 'src', true)
+				processors: createProcessors({
+					packageJson,
+					dest: distDirectory,
+					cwd: 'src',
+					dist: true
+				})
 			}
 		},
 		variables: {

--- a/tasks/util/postcss.ts
+++ b/tasks/util/postcss.ts
@@ -36,7 +36,7 @@ export function createProcessors({
 				const newFilePath = outputPath + '.js';
 				const themeKey = ' _key';
 				const packageName = packageJson.name;
-				json[themeKey] = path.join(packageName, path.basename(outputPath, '.m.css'));
+				json[themeKey] = `${packageName}/${path.basename(outputPath, '.m.css')}`;
 				fs.writeFileSync(newFilePath, umdWrapper(JSON.stringify(json)));
 			}
 		}),

--- a/tasks/util/postcss.ts
+++ b/tasks/util/postcss.ts
@@ -5,6 +5,7 @@ const postCssImport = require('postcss-import');
 const postCssNext = require('postcss-cssnext');
 const postCssModules = require('postcss-modules');
 const umdWrapper = require('./umdWrapper');
+const pkgUp = require('pkg-up');
 
 export function createProcessors(dest: string, cwd = '', dist?: boolean) {
 	return [
@@ -25,11 +26,12 @@ export function createProcessors(dest: string, cwd = '', dist?: boolean) {
 				const outputPath = path.resolve(dest, path.relative(cwd, cssFileName));
 				const newFilePath = outputPath + '.js';
 				const themeKey = ' _key';
-				json[themeKey] = 'dojo-' + path.basename(outputPath, '.m.css');
+				const packageName = require(pkgUp.sync()).name;
+				json[themeKey] = path.join(packageName, path.basename(outputPath, '.m.css'));
 				fs.writeFileSync(newFilePath, umdWrapper(JSON.stringify(json)));
 			}
 		}),
 		// autoprefixer included in cssnext
 		cssNano({ autoprefixer: false })
 	];
-};
+}

--- a/tasks/util/postcss.ts
+++ b/tasks/util/postcss.ts
@@ -5,9 +5,18 @@ const postCssImport = require('postcss-import');
 const postCssNext = require('postcss-cssnext');
 const postCssModules = require('postcss-modules');
 const umdWrapper = require('./umdWrapper');
-const pkgUp = require('pkg-up');
 
-export function createProcessors(dest: string, cwd = '', dist?: boolean) {
+export function createProcessors({
+	dest,
+	cwd = '',
+	dist,
+	packageJson
+}: {
+		dest: string,
+		cwd?: string,
+		dist?: boolean,
+		packageJson: any
+}) {
 	return [
 		postCssImport,
 		postCssNext({
@@ -26,7 +35,7 @@ export function createProcessors(dest: string, cwd = '', dist?: boolean) {
 				const outputPath = path.resolve(dest, path.relative(cwd, cssFileName));
 				const newFilePath = outputPath + '.js';
 				const themeKey = ' _key';
-				const packageName = require(pkgUp.sync()).name;
+				const packageName = packageJson.name;
 				json[themeKey] = path.join(packageName, path.basename(outputPath, '.m.css'));
 				fs.writeFileSync(newFilePath, umdWrapper(JSON.stringify(json)));
 			}

--- a/tests/unit/tasks/util/postcss.ts
+++ b/tests/unit/tasks/util/postcss.ts
@@ -163,8 +163,6 @@ registerSuite('tasks/util/postcss', {
 					assert.equal(basenameStub.firstCall.args[1], '.m.css');
 				},
 				'should call umdWrapper with the package name in the `_key` value'() {
-					joinStub.returns('@owner/widgets/widget-1');
-
 					const cssFileName = 'testFileName.m.css';
 					const jsonParam = {};
 
@@ -181,12 +179,9 @@ registerSuite('tasks/util/postcss', {
 					assert.isTrue(umdWrapperStub.calledOnce);
 
 					assert.equal(packageJsonStub.callCount, 1, 'package.json is accessed');
-					assert.equal(joinStub.callCount, 1, 'path.join is invoked once');
-					assert.equal(joinStub.firstCall.args[0], '@owner/widgets');
-					assert.equal(joinStub.firstCall.args[1], 'testFileName');
 
 					const expected = {
-						' _key': '@owner/widgets/widget-1'
+						' _key': '@owner/widgets/testFileName'
 					};
 
 					assert.equal(umdWrapperStub.firstCall.args[0], JSON.stringify(expected));


### PR DESCRIPTION

**Type:**  feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

Resolves #183 

Also improves some tests so `equals` is used rather than `isTrue` which helps with logging 