### PR TITLE
Add Prettier with tslint plugin and precommit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 The following has been addressed in the PR:
 
 * [ ] There is a related issue
-* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
 * [ ] Unit or Functional tests are included in the PR
 
 <!--

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+typings

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ module.exports = function (grunt) {
 };
 ```
 
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
+
 ### Dependencies
 
 There are several peer dependencies which you should have installed in the containing project:

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,6 @@ import 'grunt';
 
 declare const GruntDojo2: {
 	initConfig(grunt: IGrunt, otherOptions: any): void;
-}
+};
 
 export = GruntDojo2;

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@ import * as glob from 'glob';
 import ITask = grunt.task.ITask;
 
 function formatGlob(tsconfigGlob: string[]): string[] {
-	return tsconfigGlob.map(function (glob: string) {
+	return tsconfigGlob.map(function(glob: string) {
 		if (/^\.\//.test(glob)) {
 			// Remove the leading './' from the glob because grunt-ts
 			// sees it and thinks it needs to create a .baseDir.ts which
@@ -14,7 +14,7 @@ function formatGlob(tsconfigGlob: string[]): string[] {
 	});
 }
 
-exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
+exports.initConfig = function(grunt: IGrunt, otherOptions: any) {
 	const tsconfigContent = grunt.file.read('tsconfig.json');
 	const tsconfig = JSON.parse(tsconfigContent);
 	if (tsconfig.filesGlob) {
@@ -46,17 +46,9 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		'fixSourceMaps'
 	];
 
-	const distESMTasks = [
-		'dojo-ts:esm'
-	];
+	const distESMTasks = ['dojo-ts:esm'];
 
-	const docTasks = [
-		'clean:typings',
-		'typings:dev',
-		'typedoc',
-		'clean:typedoc',
-		'clean:ghpages'
-	];
+	const docTasks = ['clean:typings', 'typings:dev', 'typedoc', 'clean:typedoc', 'clean:ghpages'];
 
 	grunt.initConfig({
 		name: packageJson.name,
@@ -64,8 +56,8 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 		tsconfig: tsconfig,
 		tsconfigContent: tsconfigContent,
 		filesGlob: tsconfig.filesGlob || tsconfig.include,
-		all: [ '<%= filesGlob %>' ],
-		skipTests: [ '<%= all %>' , '!tests/**/*.ts' ],
+		all: ['<%= filesGlob %>'],
+		skipTests: ['<%= all %>', '!tests/**/*.ts'],
 		testsGlob: ['./tests/**/*.ts', 'tests/**/*.ts'],
 		staticTestFiles: 'tests/**/*.{html,css,json,xml,js,txt}',
 		staticDefinitionFiles: '**/*.d.ts',
@@ -82,12 +74,14 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	});
 
 	const options: { [option: string]: any } = {};
-	glob.sync('*.js', {
-		cwd: path.join(__dirname, 'options')
-	}).forEach(function (filename) {
-		const optName = path.basename(filename, '.js');
-		options[optName] = require('./options/' + optName)(grunt);
-	});
+	glob
+		.sync('*.js', {
+			cwd: path.join(__dirname, 'options')
+		})
+		.forEach(function(filename) {
+			const optName = path.basename(filename, '.js');
+			options[optName] = require('./options/' + optName)(grunt);
+		});
 	grunt.config.merge(options);
 
 	require('./tasks/uploadCoverage')(grunt);
@@ -108,12 +102,14 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	require('./tasks/typedoc')(grunt);
 
 	// Set some Intern-specific options if specified on the command line.
-	[ 'suites', 'functionalSuites', 'grep', 'showConfig', 'leaveRemoteOpen' ].forEach(function (option) {
+	['suites', 'functionalSuites', 'grep', 'showConfig', 'leaveRemoteOpen'].forEach(function(option) {
 		const value = grunt.option<string>(option);
 		let splitValue: string[] | undefined;
 		if (value) {
 			if (option === 'suites' || option === 'functionalSuites') {
-				splitValue = value.split(',').map(function (string) { return string.trim(); });
+				splitValue = value.split(',').map(function(string) {
+					return string.trim();
+				});
 			}
 			grunt.config('intern.options.' + option, splitValue || value);
 		}
@@ -121,13 +117,13 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 
 	function setTestReporter(testReporter: boolean) {
 		if (testReporter) {
-			grunt.config('intern.options.node.reporters', [ 'grunt-dojo2' ]);
+			grunt.config('intern.options.node.reporters', ['grunt-dojo2']);
 		}
 	}
 
 	setTestReporter(grunt.option<boolean>('test-reporter'));
 
-	grunt.registerTask('test', function () {
+	grunt.registerTask('test', function() {
 		const flags = Object.keys(this.flags);
 
 		if (!flags.length) {
@@ -152,5 +148,5 @@ exports.initConfig = function (grunt: IGrunt, otherOptions: any) {
 	grunt.registerTask('dist_esm', grunt.config.get<string[]>('distESMTasks'));
 	grunt.registerTask('doc', grunt.config.get<string[]>('docTasks'));
 
-	grunt.registerTask('default', [ 'clean', 'dev' ]);
+	grunt.registerTask('default', ['clean', 'dev']);
 };

--- a/lib/intern/Reporter.ts
+++ b/lib/intern/Reporter.ts
@@ -1,10 +1,6 @@
 import * as nodeUtil from 'util';
 import { create, ReportType } from 'istanbul-reports';
-import {
-	CoverageMap,
-	CoverageMapData,
-	createCoverageMap
-} from 'istanbul-lib-coverage';
+import { CoverageMap, CoverageMapData, createCoverageMap } from 'istanbul-lib-coverage';
 import { createContext, summarizers, Watermarks } from 'istanbul-lib-report';
 
 import Node, { NodeEvents } from 'intern/lib/executors/Node';
@@ -47,7 +43,7 @@ interface SuiteOrTest {
 }
 
 export default class Reporter extends Runner {
-	private _errors: { [sessionId: string ]: ErrorObject[] } = {};
+	private _errors: { [sessionId: string]: ErrorObject[] } = {};
 
 	directory: string;
 	lcovFilename: string;
@@ -97,7 +93,7 @@ export default class Reporter extends Runner {
 		const sessionIds = Object.keys(this.sessions);
 		const numEnvironments = sessionIds.length;
 
-		sessionIds.forEach(sessionId => {
+		sessionIds.forEach((sessionId) => {
 			const session = this.sessions[sessionId];
 			numTests += session.suite.numTests;
 			numPassedTests += session.suite.numPassedTests;
@@ -133,8 +129,7 @@ export default class Reporter extends Runner {
 
 		if (this.hasRunErrors) {
 			message += '; fatal error occurred';
-		}
-		else if (this.hasSuiteErrors) {
+		} else if (this.hasSuiteErrors) {
 			message += '; suite error occurred';
 		}
 
@@ -192,7 +187,7 @@ export default class Reporter extends Runner {
 					charm.write(LIGHT_RED);
 					charm.write('× ' + test.id);
 					charm.foreground('white');
-					charm.write(' (' + (test.timeElapsed / 1000) + 's)');
+					charm.write(' (' + test.timeElapsed / 1000 + 's)');
 					charm.write('\n');
 					charm.foreground('red');
 					charm.write(test.error);
@@ -236,12 +231,10 @@ export default class Reporter extends Runner {
 			this._addError(test);
 			charm.write(LIGHT_RED);
 			charm.write('×');
-		}
-		else if (test.skipped) {
+		} else if (test.skipped) {
 			charm.write(LIGHT_MAGENTA);
 			charm.write('~');
-		}
-		else {
+		} else {
 			charm.write(LIGHT_GREEN);
 			charm.write('✓');
 		}
@@ -266,5 +259,5 @@ function isCoverageMap(value: any): value is CoverageMap {
 }
 
 intern.registerPlugin('grunt-dojo2', () => {
-	intern.registerReporter('grunt-dojo2', options => new Reporter(intern, options));
+	intern.registerReporter('grunt-dojo2', (options) => new Reporter(intern, options));
 });

--- a/lib/intern/internLoader.ts
+++ b/lib/intern/internLoader.ts
@@ -1,28 +1,32 @@
 declare const shimAmdDependencies: any;
 
 intern.registerLoader((options) => {
-	return intern.loadScript('node_modules/@dojo/loader/loader.js')
+	return intern
+		.loadScript('node_modules/@dojo/loader/loader.js')
 		.then(() => intern.loadScript('node_modules/@dojo/shim/util/amd.js'))
 		.then(() => {
 			const { packages = [], baseUrl = intern.config.basePath } = options;
-			packages.push({ 'name': 'sinon', 'location': 'node_modules/sinon/pkg', 'main': 'sinon' });
+			packages.push({ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' });
 
-			(<any> require).config(shimAmdDependencies({
-				baseUrl,
-				...options,
-				packages
-			}));
+			(<any>require).config(
+				shimAmdDependencies({
+					baseUrl,
+					...options,
+					packages
+				})
+			);
 
 			// load @dojo/shim/main to import the ts helpers
 			return new Promise<void>((resolve) => {
-				(<any> require)(['@dojo/shim/main'], () => {
+				(<any>require)(['@dojo/shim/main'], () => {
 					resolve();
 				});
 			});
-		}).then(() => {
+		})
+		.then(() => {
 			return (modules: string[]) => {
 				return new Promise<void>((resolve, reject) => {
-					(<any> require)(modules, () => resolve());
+					(<any>require)(modules, () => resolve());
 				});
 			};
 		});

--- a/lib/load-dojo-loader.ts
+++ b/lib/load-dojo-loader.ts
@@ -2,23 +2,18 @@ import { join } from 'path';
 
 const resolveFrom = require('resolve-from');
 
-export default function loadDojoLoader ({ peerDependencies = {} }: any) {
+export default function loadDojoLoader({ peerDependencies = {} }: any) {
 	const baseUrl = process.cwd();
-	const packages = [
-		{ name: 'src', location: join('_build', 'src') }
-	];
+	const packages = [{ name: 'src', location: join('_build', 'src') }];
 
 	for (const name in peerDependencies) {
 		if (/^dojo-/.test(name)) {
 			packages.push({ name, location: join('node_modules', name, 'dist', 'all') });
-		}
-		else if (name === '@reactivex/rxjs') {
+		} else if (name === '@reactivex/rxjs') {
 			packages.push({ name: 'rxjs', location: join('node_modules', name, 'dist', 'amd') });
-		}
-		else if (name === 'maquette' || name === 'immutable') {
+		} else if (name === 'maquette' || name === 'immutable') {
 			packages.push({ name, location: join('node_modules', name, 'dist') });
-		}
-		else {
+		} else {
 			packages.push({ name, location: join('node_modules', name) });
 		}
 	}

--- a/options/clean.ts
+++ b/options/clean.ts
@@ -1,22 +1,22 @@
-export = function (grunt: IGrunt) {
+export = function(grunt: IGrunt) {
 	grunt.loadNpmTasks('grunt-contrib-clean');
 
 	return {
 		typings: {
-			src: [ 'typings/' ]
+			src: ['typings/']
 		},
 		dist: {
-			src: [ '<%= devDirectory %>/*' ],
-			filter: function (path: string) {
+			src: ['<%= devDirectory %>/*'],
+			filter: function(path: string) {
 				return grunt.option('remove-links') ? true : !grunt.file.isLink(path);
 			}
 		},
 		dev: {
-			src: [ '<%= devDirectory %>' ]
+			src: ['<%= devDirectory %>']
 		},
 		src: {
-			src: [ '{src,tests}/**/*.js' ],
-			filter: function (path: string) {
+			src: ['{src,tests}/**/*.js'],
+			filter: function(path: string) {
 				// Only clean the .js file if a .js.map file also exists
 				const mapPath = path + '.map';
 				if (grunt.file.exists(mapPath)) {
@@ -27,13 +27,13 @@ export = function (grunt: IGrunt) {
 			}
 		},
 		coverage: {
-			src: [ 'coverage-unmapped.json', 'coverage' ]
+			src: ['coverage-unmapped.json', 'coverage']
 		},
 		typedoc: {
-			src: [ '<%= apiDocDirectory %>', '<%= apiPubDirectory %>' ]
+			src: ['<%= apiDocDirectory %>', '<%= apiPubDirectory %>']
 		},
 		ghpages: {
-			src: [ '<%= apiPubDirectory %>' ]
+			src: ['<%= apiPubDirectory %>']
 		}
 	};
 };

--- a/options/copy.ts
+++ b/options/copy.ts
@@ -1,4 +1,4 @@
-export = function (grunt: IGrunt) {
+export = function(grunt: IGrunt) {
 	const path = require('path');
 
 	grunt.loadNpmTasks('grunt-contrib-copy');
@@ -7,19 +7,19 @@ export = function (grunt: IGrunt) {
 		staticTestFiles: {
 			expand: true,
 			cwd: '.',
-			src: [ '<%= staticTestFiles %>' ],
+			src: ['<%= staticTestFiles %>'],
 			dest: '<%= devDirectory %>'
 		},
 		'staticDefinitionFiles-dev': {
 			expand: true,
 			cwd: '.',
-			src: [ path.join('src', '<%= staticDefinitionFiles %>') ],
+			src: [path.join('src', '<%= staticDefinitionFiles %>')],
 			dest: '<%= devDirectory %>'
 		},
 		'staticDefinitionFiles-dist': {
 			expand: true,
 			cwd: 'src',
-			src: [ '<%= staticDefinitionFiles %>' ],
+			src: ['<%= staticDefinitionFiles %>'],
 			dest: '<%= distDirectory %>'
 		}
 	};

--- a/options/intern.ts
+++ b/options/intern.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-export = function (grunt: IGrunt) {
+export = function(grunt: IGrunt) {
 	grunt.loadNpmTasks('intern');
 
 	const progress = grunt.option<boolean>('progress');
@@ -9,12 +9,8 @@ export = function (grunt: IGrunt) {
 		options: {
 			config: '<%= internConfig %>',
 			node: {
-				'plugins+': [
-					{ script: 'grunt-dojo2/lib/intern/Reporter.js', useLoader: true }
-				],
-				reporters: [
-					{ name: 'runner', options: { 'hideSkipped': !progress, 'hidePassed': !progress } }
-				]
+				'plugins+': [{ script: 'grunt-dojo2/lib/intern/Reporter.js', useLoader: true }],
+				reporters: [{ name: 'runner', options: { hideSkipped: !progress, hidePassed: !progress } }]
 			}
 		},
 		browserstack: {

--- a/options/remapIstanbul.ts
+++ b/options/remapIstanbul.ts
@@ -1,25 +1,25 @@
-export = function (grunt: IGrunt) {
+export = function(grunt: IGrunt) {
 	grunt.loadNpmTasks('remap-istanbul');
 
 	return {
 		coverage: {
 			options: {
 				reports: {
-					'html': 'html-report',
-					'text': <any> null
+					html: 'html-report',
+					text: <any>null
 				}
 			},
-			src: [ 'coverage-unmapped.json' ]
+			src: ['coverage-unmapped.json']
 		},
 		ci: {
 			options: {
 				reports: {
-					'lcovonly': 'coverage-final.lcov',
-					'json': 'coverage-final.json',
-					'text': <any> null
+					lcovonly: 'coverage-final.lcov',
+					json: 'coverage-final.json',
+					text: <any>null
 				}
 			},
-			src: [ 'coverage-unmapped.json' ]
+			src: ['coverage-unmapped.json']
 		}
 	};
 };

--- a/options/rename.ts
+++ b/options/rename.ts
@@ -1,4 +1,4 @@
-export = function (grunt: IGrunt) {
+export = function(grunt: IGrunt) {
 	require('../tasks/rename')(grunt);
 
 	const distDirectory = grunt.config.get<string>('distDirectory');
@@ -7,7 +7,7 @@ export = function (grunt: IGrunt) {
 		sourceMaps: {
 			expand: true,
 			cwd: distDirectory,
-			src: [ '**/*.js.map', '!_debug/**/*.js.map' ],
+			src: ['**/*.js.map', '!_debug/**/*.js.map'],
 			dest: 'dist/umd/_debug/'
 		}
 	};

--- a/options/replace.ts
+++ b/options/replace.ts
@@ -1,9 +1,9 @@
-export = function (grunt: IGrunt) {
+export = function(grunt: IGrunt) {
 	grunt.loadNpmTasks('grunt-text-replace');
 
 	return {
 		addIstanbulIgnore: {
-			src: [ '<%= devDirectory %>/**/*.js' ],
+			src: ['<%= devDirectory %>/**/*.js'],
 			overwrite: true,
 			replacements: [
 				{

--- a/options/tslint.ts
+++ b/options/tslint.ts
@@ -1,4 +1,4 @@
-export = function (grunt: IGrunt) {
+export = function(grunt: IGrunt) {
 	grunt.loadNpmTasks('grunt-tslint');
 
 	return {
@@ -6,12 +6,7 @@ export = function (grunt: IGrunt) {
 			configuration: grunt.file.readJSON('tslint.json')
 		},
 		src: {
-			src: [
-				'<%= all %>',
-				'!typings/**/*.ts',
-				'!tests/typings/**/*.ts',
-				'!node_modules/**/*.ts'
-			]
+			src: ['<%= all %>', '!typings/**/*.ts', '!tests/typings/**/*.ts', '!node_modules/**/*.ts']
 		}
 	};
 };

--- a/options/typedoc.ts
+++ b/options/typedoc.ts
@@ -1,4 +1,4 @@
-export = function (_grunt: IGrunt) {
+export = function(_grunt: IGrunt) {
 	return {
 		options: {
 			// All options but publishOptions are passed directly to the typedoc command line.

--- a/options/typings.ts
+++ b/options/typings.ts
@@ -1,4 +1,4 @@
-export = function (grunt: IGrunt) {
+export = function(grunt: IGrunt) {
 	grunt.loadNpmTasks('grunt-typings');
 
 	return {

--- a/options/watch.ts
+++ b/options/watch.ts
@@ -1,4 +1,4 @@
-export = function (grunt: IGrunt) {
+export = function(grunt: IGrunt) {
 	grunt.loadNpmTasks('grunt-ts');
 
 	return {
@@ -6,16 +6,14 @@ export = function (grunt: IGrunt) {
 			options: {
 				reload: true
 			},
-			files: [ 'Gruntfile.js', 'tsconfig.json' ]
+			files: ['Gruntfile.js', 'tsconfig.json']
 		},
 		src: {
 			options: {
 				atBegin: true
 			},
-			files: [ '<%= all %>', '<%= staticTestFiles %>' ],
-			tasks: [
-				'dev'
-			]
+			files: ['<%= all %>', '<%= staticTestFiles %>'],
+			tasks: ['dev']
 		}
 	};
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-dojo2",
-  "version": "0.1.2-pre",
+  "version": "2.0.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -71,9 +71,9 @@
       }
     },
     "@types/babel-types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.0.tgz",
-      "integrity": "sha512-PyWcbX0W4r4GcgXLI0Vu4jyJ/Erueo3PwjgvQcOmWAOBW0ObhzBBciEX+sHvjkNE0umI6nqD192FDKvYZTL91A=="
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.1.tgz",
+      "integrity": "sha512-EkcOk09rjhivbovP8WreGRbXW20YRfe/qdgXOGq3it3u3aAOWDRNsQhL/XPAWFF7zhZZ+uR+nT+3b+TCkIap1w=="
     },
     "@types/benchmark": {
       "version": "1.0.31",
@@ -122,9 +122,9 @@
       "integrity": "sha512-q3zfJvaTroV5BjAAR+peTHEGAAhGrPX0z2EzCzpt2mwFA+qzUn2nigJLqSekXRtdULKmT8am7zjvTMZSapIgHw=="
     },
     "@types/events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
-      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
     },
     "@types/express": {
       "version": "4.0.39",
@@ -141,7 +141,7 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.1.tgz",
       "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
       "requires": {
-        "@types/events": "1.1.0",
+        "@types/events": "1.2.0",
         "@types/node": "9.4.6"
       },
       "dependencies": {
@@ -173,7 +173,7 @@
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/events": "1.1.0",
+        "@types/events": "1.2.0",
         "@types/minimatch": "2.0.29",
         "@types/node": "7.0.55"
       }
@@ -217,7 +217,7 @@
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
       "integrity": "sha512-Ll2qAzv7NItqVliZZ8OMAgAvGstddK2995/7X5YPU84lD3CFnqDfP4sTu5Q1GKReh5Ttw3shKR2e3Fe6Xo0C7A==",
       "requires": {
-        "@types/babel-types": "7.0.0",
+        "@types/babel-types": "7.0.1",
         "@types/istanbul-lib-coverage": "1.1.0",
         "source-map": "0.6.1"
       },
@@ -390,20 +390,20 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "negotiator": "0.6.1"
       },
       "dependencies": {
         "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "1.33.0"
           }
         }
       }
@@ -445,11 +445,25 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-align": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
+      "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
       }
     },
     "ansi-cyan": {
@@ -489,6 +503,12 @@
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
     },
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
+      "dev": true
+    },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -502,6 +522,12 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
     },
     "append-transform": {
       "version": "0.4.0",
@@ -628,7 +654,7 @@
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000808",
+        "caniuse-db": "1.0.30000810",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -714,7 +740,7 @@
         "babylon": "6.18.0",
         "debug": "2.6.9",
         "globals": "9.18.0",
-        "invariant": "2.2.2",
+        "invariant": "2.2.3",
         "lodash": "4.17.5"
       },
       "dependencies": {
@@ -805,7 +831,7 @@
         "on-finished": "2.3.0",
         "qs": "5.2.0",
         "raw-body": "2.1.7",
-        "type-is": "1.6.15"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "qs": {
@@ -824,53 +850,37 @@
       }
     },
     "boxen": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
+      "dev": true,
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.3.1",
+        "ansi-align": "1.1.0",
+        "camelcase": "2.1.1",
+        "chalk": "1.1.3",
         "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
+        "filled-array": "1.1.0",
+        "object-assign": "4.1.1",
+        "repeating": "2.0.1",
+        "string-width": "1.0.2",
+        "widest-line": "1.0.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
         "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
         },
-        "chalk": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.2.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
-          "requires": {
-            "has-flag": "3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -906,8 +916,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "requires": {
-        "caniuse-db": "1.0.30000808",
-        "electron-to-chromium": "1.3.33"
+        "caniuse-db": "1.0.30000810",
+        "electron-to-chromium": "1.3.34"
       }
     },
     "buffer": {
@@ -972,20 +982,21 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000808",
+        "caniuse-db": "1.0.30000810",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000808",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000808.tgz",
-      "integrity": "sha1-MN/YMAnVcE8C3/s3clBo7RKjZrs="
+      "version": "1.0.30000810",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000810.tgz",
+      "integrity": "sha1-vSWDDEHvq2Qzmi44H0lnc0PIRQk="
     },
     "capture-stack-trace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
     },
     "caseless": {
       "version": "0.6.0",
@@ -1063,6 +1074,12 @@
         "readdirp": "1.4.0"
       }
     },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
+    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -1074,7 +1091,8 @@
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
     },
     "cli-cursor": {
       "version": "1.0.2",
@@ -1084,6 +1102,12 @@
       "requires": {
         "restore-cursor": "1.0.1"
       }
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
     },
     "cli-truncate": {
       "version": "0.2.1",
@@ -1095,15 +1119,6 @@
         "string-width": "1.0.2"
       },
       "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1248,9 +1263,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+      "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.4",
@@ -1296,7 +1311,7 @@
         "mkdirp": "0.5.1",
         "object-assign": "4.1.1",
         "os-tmpdir": "1.0.2",
-        "osenv": "0.1.4",
+        "osenv": "0.1.5",
         "uuid": "2.0.3",
         "write-file-atomic": "1.3.4",
         "xdg-basedir": "2.0.0"
@@ -1332,10 +1347,50 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        }
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
       "requires": {
         "capture-stack-trace": "1.0.0"
       }
@@ -1367,11 +1422,6 @@
       "requires": {
         "boom": "0.4.2"
       }
-    },
-    "crypto-random-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "csproj2ts": {
       "version": "0.0.7",
@@ -1542,6 +1592,12 @@
         "array-find-index": "1.0.2"
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
@@ -1575,7 +1631,7 @@
         "decompress-targz": "4.1.1",
         "decompress-unzip": "4.0.1",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
+        "make-dir": "1.2.0",
         "pify": "2.3.0",
         "strip-dirs": "2.1.0"
       }
@@ -1636,6 +1692,12 @@
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
         }
       }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -1795,20 +1857,15 @@
         }
       }
     },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.33",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
-      "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU="
+      "version": "1.3.34",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.34.tgz",
+      "integrity": "sha1-2TSY9AORuwwWpgPYJBuZUUBBV+0="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -1958,7 +2015,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.5.tgz",
       "integrity": "sha1-ZwI1ypWYiQpa6BcLg9tyK4Qu2Sc=",
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "content-disposition": "0.5.2",
         "content-type": "1.0.4",
@@ -1983,7 +2040,7 @@
         "serve-static": "1.12.6",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.0",
         "vary": "1.1.2"
       },
@@ -2060,6 +2117,16 @@
         "pend": "1.2.0"
       }
     },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
+    },
     "file-sync-cmp": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
@@ -2127,6 +2194,12 @@
         }
       }
     },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
+    },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -2140,6 +2213,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+      "dev": true,
       "requires": {
         "glob": "5.0.15"
       },
@@ -2148,6 +2222,7 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
           "requires": {
             "inflight": "1.0.6",
             "inherits": "2.0.3",
@@ -2236,7 +2311,7 @@
       "integrity": "sha1-mZLxAyySXIKVVNDVmAHcoDE6U1Y=",
       "optional": true,
       "requires": {
-        "nan": "2.8.0"
+        "nan": "2.9.2"
       }
     },
     "function-bind": {
@@ -2269,6 +2344,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+      "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -2359,14 +2440,6 @@
         }
       }
     },
-    "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "requires": {
-        "ini": "1.3.5"
-      }
-    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -2383,27 +2456,57 @@
       }
     },
     "got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+      "dev": true,
       "requires": {
         "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
+        "duplexer2": "0.1.4",
         "is-redirect": "1.0.0",
         "is-retry-allowed": "1.1.0",
         "is-stream": "1.1.0",
         "lowercase-keys": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
+        "node-status-codes": "1.0.0",
+        "object-assign": "4.1.1",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "read-all-stream": "3.1.0",
+        "readable-stream": "2.3.4",
+        "timed-out": "3.1.3",
+        "unzip-response": "1.0.2",
         "url-parse-lax": "1.0.0"
       },
       "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+          "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
         }
       }
     },
@@ -2431,7 +2534,7 @@
         "glob": "7.0.6",
         "grunt-cli": "1.2.0",
         "grunt-known-options": "1.1.0",
-        "grunt-legacy-log": "1.0.0",
+        "grunt-legacy-log": "1.0.1",
         "grunt-legacy-util": "1.0.0",
         "iconv-lite": "0.4.13",
         "js-yaml": "3.5.5",
@@ -2555,29 +2658,27 @@
       "dev": true
     },
     "grunt-legacy-log": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz",
-      "integrity": "sha1-+4bxgJhHvAfcR4Q/ns1srLYt8tU=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.1.tgz",
+      "integrity": "sha512-rwuyqNKlI0IPz0DvxzJjcEiQEBaBNVeb1LFoZKxSmHLETFUwhwUrqOsPIxURTKSwNZHZ4ht1YLBYmVU0YZAzHQ==",
       "dev": true,
       "requires": {
         "colors": "1.1.2",
         "grunt-legacy-log-utils": "1.0.0",
         "hooker": "0.2.3",
-        "lodash": "3.10.1",
-        "underscore.string": "3.2.3"
+        "lodash": "4.17.5",
+        "underscore.string": "3.3.4"
       },
       "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
         "underscore.string": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
-          "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to=",
-          "dev": true
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+          "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
         }
       }
     },
@@ -2694,9 +2795,10 @@
       }
     },
     "grunt-tslint": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
-      "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.1.tgz",
+      "integrity": "sha1-dDK9G9VuijolAACI1cYf3MNC8MI=",
+      "dev": true
     },
     "grunt-typings": {
       "version": "0.1.5",
@@ -2850,6 +2952,31 @@
         "extend": "3.0.1"
       }
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.1.0",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
@@ -2869,11 +2996,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
-    },
-    "import-lazy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -2936,7 +3058,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.1",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.102",
+        "@types/lodash": "4.14.104",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -2959,7 +3081,7 @@
         "istanbul-lib-source-maps": "1.2.3",
         "istanbul-reports": "1.1.4",
         "lodash": "4.17.5",
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "minimatch": "3.0.4",
         "platform": "1.3.5",
         "resolve": "1.4.0",
@@ -2971,9 +3093,9 @@
       },
       "dependencies": {
         "@types/lodash": {
-          "version": "4.14.102",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.102.tgz",
-          "integrity": "sha512-k/SxycYmVc6sYo6kzm8cABHcbMs9MXn6jYsja1hLvZ/x9e31VHRRn+1UzWdpv6doVchphvKaOsZ0VTqbF7zvNg=="
+          "version": "4.14.104",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz",
+          "integrity": "sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ=="
         },
         "body-parser": {
           "version": "1.17.2",
@@ -2989,7 +3111,7 @@
             "on-finished": "2.3.0",
             "qs": "6.4.0",
             "raw-body": "2.2.0",
-            "type-is": "1.6.15"
+            "type-is": "1.6.16"
           }
         },
         "bytes": {
@@ -3048,11 +3170,11 @@
           }
         },
         "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "1.33.0"
           }
         },
         "ms": {
@@ -3093,9 +3215,9 @@
       "integrity": "sha512-sRobbVo/+DVGkbco/UkuREmXSr5ypWeQ7S7tYDhzIIP3NFtAHLkkFYdivFAIgNe4sfDYBFAjxEgUyxiEmA/dgQ=="
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+      "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -3150,6 +3272,21 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-ci": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -3182,23 +3319,17 @@
       }
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-glob": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
       "integrity": "sha1-tMZLgwPTkRRJKkYNNkzPsNPAoEU="
-    },
-    "is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
-      }
     },
     "is-natural-number": {
       "version": "4.0.1",
@@ -3208,7 +3339,8 @@
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
     },
     "is-number": {
       "version": "2.1.0",
@@ -3223,12 +3355,13 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "symbol-observable": "0.2.4"
       }
     },
     "is-plain-obj": {
@@ -3246,10 +3379,23 @@
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
     },
     "is-relative": {
       "version": "0.2.1",
@@ -3262,7 +3408,8 @@
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -3467,6 +3614,61 @@
         "handlebars": "4.0.11"
       }
     },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.1",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
@@ -3565,11 +3767,12 @@
       }
     },
     "latest-version": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+      "dev": true,
       "requires": {
-        "package-json": "4.0.1"
+        "package-json": "2.4.0"
       }
     },
     "lazy-cache": {
@@ -3592,6 +3795,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3609,10 +3818,240 @@
         "immediate": "3.0.6"
       }
     },
+    "lint-staged": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.1",
+        "commander": "2.14.1",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.5",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "listify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
       "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM="
+    },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.6",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      }
     },
     "livereload-js": {
       "version": "2.3.0",
@@ -3706,6 +4145,52 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "log-update": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
@@ -3748,7 +4233,8 @@
     "lowercase-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.1",
@@ -3765,9 +4251,9 @@
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
     },
     "make-dir": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "requires": {
         "pify": "3.0.0"
       },
@@ -3799,9 +4285,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
-      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA=="
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.17.tgz",
+      "integrity": "sha512-+AKbNsjZl6jFfLPwHhWmGTqE009wTKn3RTmn9K8oUKHrX/abPJjtcRtXpYB/FFrwPJRUA86LX/de3T0knkPCmQ=="
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -3939,9 +4425,9 @@
       "optional": true
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
       "version": "1.0.2",
@@ -3986,9 +4472,9 @@
       "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
       "optional": true
     },
     "ncp": {
@@ -4028,7 +4514,7 @@
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -4055,12 +4541,40 @@
         "sort-keys": "1.1.2"
       }
     },
+    "npm-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+      "dev": true,
+      "requires": {
+        "which": "1.3.0"
+      }
+    },
     "npm-run-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
       "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
       "requires": {
         "path-key": "1.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.14.1",
+        "npm-path": "2.0.4",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "dev": true
+        }
       }
     },
     "num2fraction": {
@@ -4164,6 +4678,18 @@
         }
       }
     },
+    "ora": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
+      }
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -4219,9 +4745,9 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -4248,17 +4774,24 @@
         "p-limit": "1.2.0"
       }
     },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
+      "dev": true,
       "requires": {
-        "got": "6.7.1",
+        "got": "5.7.1",
         "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0",
         "semver": "5.5.0"
@@ -4335,7 +4868,8 @@
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
     },
     "path-key": {
       "version": "1.0.0",
@@ -4468,11 +5002,11 @@
       "requires": {
         "any-promise": "1.3.0",
         "arrify": "1.0.1",
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.1",
         "form-data": "2.3.2",
         "make-error-cause": "1.2.2",
         "throwback": "1.1.1",
-        "tough-cookie": "2.3.3",
+        "tough-cookie": "2.3.4",
         "xtend": "4.0.1"
       },
       "dependencies": {
@@ -4496,15 +5030,15 @@
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "2.1.17"
+            "mime-types": "2.1.18"
           }
         },
         "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "1.33.0"
           }
         }
       }
@@ -4837,14 +5371,14 @@
       "resolved": "https://registry.npmjs.org/postcss-image-set-polyfill/-/postcss-image-set-polyfill-0.3.5.tgz",
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "requires": {
-        "postcss": "6.0.18",
+        "postcss": "6.0.19",
         "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -4854,9 +5388,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -4865,13 +5399,13 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "postcss": {
-          "version": "6.0.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.18.tgz",
-          "integrity": "sha512-X8MyLi3OYI1o71u0SsefWLpGBo5xnGiK1Pn+nrZFplc671Ts7L8aPwEbPIO8AWpulK5wuaVzyM9Rw6R8o7hYBw==",
+          "version": "6.0.19",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
           "requires": {
             "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -4880,9 +5414,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -5016,13 +5550,13 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "requires": {
-        "postcss": "6.0.18"
+        "postcss": "6.0.19"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -5032,9 +5566,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -5043,13 +5577,13 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "postcss": {
-          "version": "6.0.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.18.tgz",
-          "integrity": "sha512-X8MyLi3OYI1o71u0SsefWLpGBo5xnGiK1Pn+nrZFplc671Ts7L8aPwEbPIO8AWpulK5wuaVzyM9Rw6R8o7hYBw==",
+          "version": "6.0.19",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
           "requires": {
             "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -5058,9 +5592,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -5073,13 +5607,13 @@
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.18"
+        "postcss": "6.0.19"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -5089,9 +5623,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -5100,13 +5634,13 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "postcss": {
-          "version": "6.0.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.18.tgz",
-          "integrity": "sha512-X8MyLi3OYI1o71u0SsefWLpGBo5xnGiK1Pn+nrZFplc671Ts7L8aPwEbPIO8AWpulK5wuaVzyM9Rw6R8o7hYBw==",
+          "version": "6.0.19",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
           "requires": {
             "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -5115,9 +5649,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -5130,13 +5664,13 @@
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.18"
+        "postcss": "6.0.19"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -5146,9 +5680,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -5157,13 +5691,13 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "postcss": {
-          "version": "6.0.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.18.tgz",
-          "integrity": "sha512-X8MyLi3OYI1o71u0SsefWLpGBo5xnGiK1Pn+nrZFplc671Ts7L8aPwEbPIO8AWpulK5wuaVzyM9Rw6R8o7hYBw==",
+          "version": "6.0.19",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
           "requires": {
             "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -5172,9 +5706,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -5187,13 +5721,13 @@
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.18"
+        "postcss": "6.0.19"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -5203,9 +5737,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -5214,13 +5748,13 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "postcss": {
-          "version": "6.0.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.18.tgz",
-          "integrity": "sha512-X8MyLi3OYI1o71u0SsefWLpGBo5xnGiK1Pn+nrZFplc671Ts7L8aPwEbPIO8AWpulK5wuaVzyM9Rw6R8o7hYBw==",
+          "version": "6.0.19",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
           "requires": {
             "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -5229,9 +5763,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -5423,6 +5957,39 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -5756,6 +6323,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
       "requires": {
         "rc": "1.2.5",
         "safe-buffer": "5.1.1"
@@ -5765,6 +6333,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
       "requires": {
         "rc": "1.2.5"
       }
@@ -5850,7 +6419,7 @@
         "oauth-sign": "0.4.0",
         "qs": "1.2.2",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
+        "tough-cookie": "2.3.4",
         "tunnel-agent": "0.4.3"
       }
     },
@@ -5858,6 +6427,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
@@ -5922,6 +6497,23 @@
         "glob": "7.1.2"
       }
     },
+    "rxjs": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -5955,6 +6547,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
       "requires": {
         "semver": "5.5.0"
       }
@@ -6157,22 +6750,32 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+    },
     "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
     },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
     },
     "split": {
       "version": "0.2.10",
@@ -6187,6 +6790,12 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -6198,6 +6807,15 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "requires": {
         "duplexer": "0.1.1"
+      }
+    },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
       }
     },
     "strict-uri-encode": {
@@ -6229,6 +6847,11 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -6243,6 +6866,17 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringify-object": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
+      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -6315,6 +6949,12 @@
         "whet.extend": "0.9.9"
       }
     },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
+    },
     "tape": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.0.tgz",
@@ -6375,48 +7015,6 @@
           "requires": {
             "safe-buffer": "5.1.1"
           }
-        }
-      }
-    },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "requires": {
-        "execa": "0.7.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "requires": {
-            "path-key": "2.0.1"
-          }
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         }
       }
     },
@@ -6481,9 +7079,10 @@
       }
     },
     "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
+      "dev": true
     },
     "tiny-lr": {
       "version": "0.2.1",
@@ -6519,9 +7118,9 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
         "punycode": "1.4.1"
       }
@@ -6543,9 +7142,10 @@
       "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
     },
     "tslint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
-      "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
+      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
+      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "colors": "1.1.2",
@@ -6554,21 +7154,24 @@
         "glob": "7.1.2",
         "optimist": "0.6.1",
         "resolve": "1.4.0",
-        "tsutils": "1.9.1",
-        "update-notifier": "2.3.0"
+        "semver": "5.5.0",
+        "tslib": "1.8.1",
+        "tsutils": "1.9.1"
       },
       "dependencies": {
         "diff": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
         }
       }
     },
     "tsutils": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
-      "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA="
+      "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.4.3",
@@ -6589,20 +7192,20 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "2.1.18"
       },
       "dependencies": {
         "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "1.33.0"
           }
         }
       }
@@ -6623,9 +7226,9 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -6645,9 +7248,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "chokidar": {
@@ -6694,7 +7297,7 @@
           "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
           "optional": true,
           "requires": {
-            "nan": "2.8.0",
+            "nan": "2.9.2",
             "node-pre-gyp": "0.6.39"
           },
           "dependencies": {
@@ -7490,14 +8093,6 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -7545,9 +8140,9 @@
           }
         },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -7587,7 +8182,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.102",
+        "@types/lodash": "4.14.104",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -7595,7 +8190,7 @@
         "handlebars": "4.0.5",
         "highlight.js": "9.12.0",
         "lodash": "4.17.5",
-        "marked": "0.3.12",
+        "marked": "0.3.17",
         "minimatch": "3.0.4",
         "progress": "1.1.8",
         "shelljs": "0.7.8",
@@ -7604,9 +8199,9 @@
       },
       "dependencies": {
         "@types/lodash": {
-          "version": "4.14.102",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.102.tgz",
-          "integrity": "sha512-k/SxycYmVc6sYo6kzm8cABHcbMs9MXn6jYsja1hLvZ/x9e31VHRRn+1UzWdpv6doVchphvKaOsZ0VTqbF7zvNg=="
+          "version": "4.14.104",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz",
+          "integrity": "sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ=="
         },
         "@types/node": {
           "version": "9.4.6",
@@ -7687,174 +8282,11 @@
         "xtend": "4.0.1"
       },
       "dependencies": {
-        "ansi-align": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
-          "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "boxen": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
-          "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
-          "dev": true,
-          "requires": {
-            "ansi-align": "1.1.0",
-            "camelcase": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-boxes": "1.0.0",
-            "filled-array": "1.1.0",
-            "object-assign": "4.1.1",
-            "repeating": "2.0.1",
-            "string-width": "1.0.2",
-            "widest-line": "1.0.0"
-          }
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "got": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-          "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
-          "dev": true,
-          "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer2": "0.1.4",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
-            "node-status-codes": "1.0.0",
-            "object-assign": "4.1.1",
-            "parse-json": "2.2.0",
-            "pinkie-promise": "2.0.1",
-            "read-all-stream": "3.1.0",
-            "readable-stream": "2.3.4",
-            "timed-out": "3.1.3",
-            "unzip-response": "1.0.2",
-            "url-parse-lax": "1.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "latest-version": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
-          "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
-          "dev": true,
-          "requires": {
-            "package-json": "2.4.0"
-          }
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
-        },
-        "package-json": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
-          "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
-          "dev": true,
-          "requires": {
-            "got": "5.7.1",
-            "registry-auth-token": "3.3.2",
-            "registry-url": "3.1.0",
-            "semver": "5.5.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
-          "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "timed-out": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-          "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
-          "dev": true
-        },
-        "unzip-response": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-          "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-          "dev": true
-        },
-        "update-notifier": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
-          "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
-          "dev": true,
-          "requires": {
-            "boxen": "0.6.0",
-            "chalk": "1.1.3",
-            "configstore": "2.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "2.0.0",
-            "lazy-req": "1.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "2.0.0"
-          }
-        },
-        "widest-line": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-          "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
         },
         "wordwrap": {
           "version": "1.0.0",
@@ -7876,7 +8308,7 @@
         "detect-indent": "4.0.0",
         "graceful-fs": "4.1.11",
         "has": "1.0.1",
-        "invariant": "2.2.2",
+        "invariant": "2.2.3",
         "is-absolute": "0.2.6",
         "listify": "1.0.0",
         "lockfile": "1.0.3",
@@ -7898,15 +8330,15 @@
         "thenify": "3.3.0",
         "throat": "3.2.0",
         "touch": "1.0.0",
-        "typescript": "2.7.1",
+        "typescript": "2.7.2",
         "xtend": "4.0.1",
         "zip-object": "0.1.0"
       },
       "dependencies": {
         "typescript": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
-          "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw=="
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+          "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
         }
       }
     },
@@ -7979,14 +8411,6 @@
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
     },
-    "unique-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "requires": {
-        "crypto-random-string": "1.0.0"
-      }
-    },
     "units-css": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
@@ -8002,99 +8426,32 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+      "dev": true
     },
     "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+      "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
+      "dev": true,
       "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.3.1",
-        "configstore": "3.1.1",
-        "import-lazy": "2.1.0",
-        "is-installed-globally": "0.1.0",
+        "boxen": "0.6.0",
+        "chalk": "1.1.3",
+        "configstore": "2.1.0",
         "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
+        "latest-version": "2.0.0",
+        "lazy-req": "1.1.0",
         "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.2.0"
-          }
-        },
-        "configstore": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-          "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
-          "requires": {
-            "dot-prop": "4.2.0",
-            "graceful-fs": "4.1.11",
-            "make-dir": "1.1.0",
-            "unique-string": "1.0.0",
-            "write-file-atomic": "2.3.0",
-            "xdg-basedir": "3.0.0"
-          }
-        },
-        "dot-prop": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-          "requires": {
-            "is-obj": "1.0.1"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        },
-        "write-file-atomic": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
-        }
+        "xdg-basedir": "2.0.0"
       }
     },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
       "requires": {
         "prepend-http": "1.0.4"
       }
@@ -8140,12 +8497,12 @@
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "vary": {
@@ -8205,11 +8562,25 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "widest-line": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
       }
     },
     "window-size": {
@@ -8232,14 +8603,6 @@
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-dojo2",
-  "version": "2.0.0-pre",
+  "version": "0.1.4-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7303,12 +7303,14 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+              "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
               "optional": true
             },
             "ajv": {
               "version": "4.11.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+              "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
               "optional": true,
               "requires": {
                 "co": "4.6.0",
@@ -7317,16 +7319,19 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
             },
             "aproba": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+              "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
               "optional": true,
               "requires": {
                 "delegates": "1.0.0",
@@ -7335,36 +7340,43 @@
             },
             "asn1": {
               "version": "0.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
               "optional": true
             },
             "assert-plus": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
               "optional": true
             },
             "asynckit": {
               "version": "0.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
               "optional": true
             },
             "aws-sign2": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
               "optional": true
             },
             "aws4": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
               "optional": true
             },
             "balanced-match": {
               "version": "0.4.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
             },
             "bcrypt-pbkdf": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+              "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
               "optional": true,
               "requires": {
                 "tweetnacl": "0.14.5"
@@ -7372,21 +7384,24 @@
             },
             "block-stream": {
               "version": "0.0.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
               "requires": {
                 "inherits": "2.0.3"
               }
             },
             "boom": {
               "version": "2.10.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
               "requires": {
                 "hoek": "2.16.3"
               }
             },
             "brace-expansion": {
               "version": "1.1.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+              "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
               "requires": {
                 "balanced-match": "0.4.2",
                 "concat-map": "0.0.1"
@@ -7394,51 +7409,61 @@
             },
             "buffer-shims": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
             },
             "caseless": {
               "version": "0.12.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
               "optional": true
             },
             "co": {
               "version": "4.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
             },
             "combined-stream": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "requires": {
                 "delayed-stream": "1.0.0"
               }
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
             },
             "cryptiles": {
               "version": "2.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
               "requires": {
                 "boom": "2.10.1"
               }
             },
             "dashdash": {
               "version": "1.14.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
               "optional": true,
               "requires": {
                 "assert-plus": "1.0.0"
@@ -7446,14 +7471,16 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "optional": true
                 }
               }
             },
             "debug": {
               "version": "2.6.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
               "optional": true,
               "requires": {
                 "ms": "2.0.0"
@@ -7461,26 +7488,31 @@
             },
             "deep-extend": {
               "version": "0.4.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
               "optional": true
             },
             "delayed-stream": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+              "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
               "optional": true
             },
             "ecc-jsbn": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+              "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
               "optional": true,
               "requires": {
                 "jsbn": "0.1.1"
@@ -7488,21 +7520,25 @@
             },
             "extend": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
               "optional": true
             },
             "extsprintf": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+              "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
             },
             "forever-agent": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
               "optional": true
             },
             "form-data": {
               "version": "2.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
               "optional": true,
               "requires": {
                 "asynckit": "0.4.0",
@@ -7512,11 +7548,13 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
             },
             "fstream": {
               "version": "1.0.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "requires": {
                 "graceful-fs": "4.1.11",
                 "inherits": "2.0.3",
@@ -7526,7 +7564,8 @@
             },
             "fstream-ignore": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
               "optional": true,
               "requires": {
                 "fstream": "1.0.11",
@@ -7536,7 +7575,8 @@
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "optional": true,
               "requires": {
                 "aproba": "1.1.1",
@@ -7551,7 +7591,8 @@
             },
             "getpass": {
               "version": "0.1.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+              "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
               "optional": true,
               "requires": {
                 "assert-plus": "1.0.0"
@@ -7559,14 +7600,16 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "optional": true
                 }
               }
             },
             "glob": {
               "version": "7.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "requires": {
                 "fs.realpath": "1.0.0",
                 "inflight": "1.0.6",
@@ -7578,16 +7621,19 @@
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
             },
             "har-schema": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+              "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
               "optional": true
             },
             "har-validator": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
               "optional": true,
               "requires": {
                 "ajv": "4.11.8",
@@ -7596,12 +7642,14 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "optional": true
             },
             "hawk": {
               "version": "3.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
               "requires": {
                 "boom": "2.10.1",
                 "cryptiles": "2.0.5",
@@ -7611,11 +7659,13 @@
             },
             "hoek": {
               "version": "2.16.3",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
             },
             "http-signature": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
               "optional": true,
               "requires": {
                 "assert-plus": "0.2.0",
@@ -7625,7 +7675,8 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "requires": {
                 "once": "1.4.0",
                 "wrappy": "1.0.2"
@@ -7633,37 +7684,44 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "ini": {
               "version": "1.3.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "requires": {
                 "number-is-nan": "1.0.1"
               }
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
               "optional": true
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
             },
             "isstream": {
               "version": "0.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
               "optional": true
             },
             "jodid25519": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+              "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
               "optional": true,
               "requires": {
                 "jsbn": "0.1.1"
@@ -7671,17 +7729,20 @@
             },
             "jsbn": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+              "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
               "optional": true
             },
             "json-schema": {
               "version": "0.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
               "optional": true
             },
             "json-stable-stringify": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
               "optional": true,
               "requires": {
                 "jsonify": "0.0.0"
@@ -7689,17 +7750,20 @@
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
               "optional": true
             },
             "jsonify": {
               "version": "0.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
               "optional": true
             },
             "jsprim": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+              "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
               "optional": true,
               "requires": {
                 "assert-plus": "1.0.0",
@@ -7710,48 +7774,56 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "optional": true
                 }
               }
             },
             "mime-db": {
               "version": "1.27.0",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+              "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
             },
             "mime-types": {
               "version": "2.1.15",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+              "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
               "requires": {
                 "mime-db": "1.27.0"
               }
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
                 "brace-expansion": "1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
                 "minimist": "0.0.8"
               }
             },
             "ms": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "optional": true
             },
             "node-pre-gyp": {
               "version": "0.6.39",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+              "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
               "optional": true,
               "requires": {
                 "detect-libc": "1.0.2",
@@ -7769,7 +7841,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "optional": true,
               "requires": {
                 "abbrev": "1.1.0",
@@ -7778,7 +7851,8 @@
             },
             "npmlog": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+              "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
               "optional": true,
               "requires": {
                 "are-we-there-yet": "1.1.4",
@@ -7789,38 +7863,45 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "requires": {
                 "wrappy": "1.0.2"
               }
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "optional": true
             },
             "osenv": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
               "optional": true,
               "requires": {
                 "os-homedir": "1.0.2",
@@ -7829,30 +7910,36 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
             },
             "performance-now": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+              "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
               "optional": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
             },
             "punycode": {
               "version": "1.4.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
               "optional": true
             },
             "qs": {
               "version": "6.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
               "optional": true
             },
             "rc": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
               "optional": true,
               "requires": {
                 "deep-extend": "0.4.2",
@@ -7863,14 +7950,16 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "optional": true
                 }
               }
             },
             "readable-stream": {
               "version": "2.2.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+              "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
               "requires": {
                 "buffer-shims": "1.0.0",
                 "core-util-is": "1.0.2",
@@ -7883,7 +7972,8 @@
             },
             "request": {
               "version": "2.81.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "optional": true,
               "requires": {
                 "aws-sign2": "0.6.0",
@@ -7912,40 +8002,47 @@
             },
             "rimraf": {
               "version": "2.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
               "requires": {
                 "glob": "7.1.2"
               }
             },
             "safe-buffer": {
               "version": "5.0.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
             },
             "semver": {
               "version": "5.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "optional": true
             },
             "sntp": {
               "version": "1.0.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
               "requires": {
                 "hoek": "2.16.3"
               }
             },
             "sshpk": {
               "version": "1.13.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+              "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
               "optional": true,
               "requires": {
                 "asn1": "0.2.3",
@@ -7961,14 +8058,16 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "optional": true
                 }
               }
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
@@ -7977,31 +8076,36 @@
             },
             "string_decoder": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+              "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
               "requires": {
                 "safe-buffer": "5.0.1"
               }
             },
             "stringstream": {
               "version": "0.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
               "optional": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "2.1.1"
               }
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "optional": true
             },
             "tar": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "requires": {
                 "block-stream": "0.0.9",
                 "fstream": "1.0.11",
@@ -8010,7 +8114,8 @@
             },
             "tar-pack": {
               "version": "3.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+              "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
               "optional": true,
               "requires": {
                 "debug": "2.6.8",
@@ -8025,7 +8130,8 @@
             },
             "tough-cookie": {
               "version": "2.3.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
               "optional": true,
               "requires": {
                 "punycode": "1.4.1"
@@ -8033,7 +8139,8 @@
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "optional": true,
               "requires": {
                 "safe-buffer": "5.0.1"
@@ -8041,26 +8148,31 @@
             },
             "tweetnacl": {
               "version": "0.14.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
               "optional": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
               "optional": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
             },
             "uuid": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
               "optional": true
             },
             "verror": {
               "version": "1.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+              "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
               "optional": true,
               "requires": {
                 "extsprintf": "1.0.2"
@@ -8068,7 +8180,8 @@
             },
             "wide-align": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
               "optional": true,
               "requires": {
                 "string-width": "1.0.2"
@@ -8076,7 +8189,8 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "scripts": {
     "build": "tsc",
     "prepublish": "shx rm -rf ./typings && typings install && tsc -p .",
+    "precommit": "lint-staged",
+    "prettier": "prettier --write '**/*.ts'",
     "test": "tsc -p . && intern",
     "ci": "rm -rf tmp && tsc -p . && intern config=@ci && cat ./lcov.info | ./node_modules/.bin/codecov"
   },
@@ -46,7 +48,6 @@
     "grunt-postcss": "^0.8.0",
     "grunt-text-replace": ">=0.4.0",
     "grunt-ts": ">=5.0.0",
-    "grunt-tslint": "^4.0.1",
     "grunt-typings": "^0.1.5",
     "intern": "~4.1.0",
     "istanbul-lib-coverage": "~1.1.1",
@@ -61,7 +62,6 @@
     "remap-istanbul": ">=0.6.3",
     "resolve-from": "^2.0.0",
     "shelljs": "^0.7.6",
-    "tslint": "^4.5.1",
     "typed-css-modules": "^0.3.1",
     "typedoc": "0.5.9",
     "umd-wrapper": "^0.1.0"
@@ -76,11 +76,30 @@
     "@types/sinon": "~1.16.32",
     "dojo-loader": "latest",
     "grunt": "^1.0.1",
+    "grunt-tslint": "5.0.1",
+    "husky": "0.14.3",
     "istanbul-lib-instrument": "^1.9.1",
+    "lint-staged": "6.0.0",
     "mockery": "^2.0.0",
+    "prettier": "1.9.2",
     "shx": ">=0.1.2",
     "sinon": "^1.17.6",
+    "tslint": "5.2.0",
     "typescript": "~2.6.1",
     "typings": "^1.3.1"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/tasks/fixSourceMaps.ts
+++ b/tasks/fixSourceMaps.ts
@@ -1,5 +1,4 @@
-export = function (grunt: IGrunt) {
-
+export = function(grunt: IGrunt) {
 	/**
 	 * When compiling with --inlineSources, tsc generates sources which include folder
 	 * paths. Until this is fixed, we need to remove paths leaving just the filename.
@@ -14,10 +13,10 @@ export = function (grunt: IGrunt) {
 		return sourceMap;
 	}
 
-	grunt.registerTask('fixSourceMaps', <any> function () {
+	grunt.registerTask('fixSourceMaps', <any>function() {
 		const dist = grunt.config('distDirectory');
-		const fixers = [ fixSources ];
-		grunt.file.expand({ filter: 'isFile'}, [dist + '/**/*.js.map']).forEach(function(path) {
+		const fixers = [fixSources];
+		grunt.file.expand({ filter: 'isFile' }, [dist + '/**/*.js.map']).forEach(function(path) {
 			const inputSourceMap = grunt.file.readJSON(path);
 			const outputSourceMap = fixers.reduce((sourceMap, fixer) => fixer(sourceMap), inputSourceMap);
 			grunt.file.write(path, JSON.stringify(outputSourceMap));

--- a/tasks/installPeerDependencies.ts
+++ b/tasks/installPeerDependencies.ts
@@ -1,7 +1,7 @@
 import { execSync as exec } from 'child_process';
 
 export = function(grunt: IGrunt, packageJson: any) {
-	grunt.registerTask('peerDepInstall', <any> function () {
+	grunt.registerTask('peerDepInstall', <any>function() {
 		const peerDeps = packageJson.peerDependencies;
 		let packageCmd = 'npm install';
 		let message = '';
@@ -22,8 +22,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 				grunt.log.verbose.error(error);
 				grunt.log.error('failed.');
 			}
-		}
-		else {
+		} else {
 			grunt.log.write('No peer dependencies detected.');
 		}
 	});

--- a/tasks/link.ts
+++ b/tasks/link.ts
@@ -7,30 +7,21 @@ export = function(grunt: IGrunt, packageJson: any) {
 	const process = require('process');
 	const pkgDir = require('pkg-dir');
 
-	grunt.registerTask('_link', '', function (this: ITask) {
+	grunt.registerTask('_link', '', function(this: ITask) {
 		const done = this.async();
 		const packagePath = pkgDir.sync(process.cwd());
 		const targetPath = grunt.config('distDirectory');
 
-		fs.symlink(
-			path.join(packagePath, 'node_modules'),
-			path.join(targetPath, 'node_modules'),
-			'junction',
-			() => {}
-		);
-		fs.symlink(
-			path.join(packagePath, 'package.json'),
-			path.join(targetPath, 'package.json'),
-			'file',
-			() => {}
-		);
+		fs.symlink(path.join(packagePath, 'node_modules'), path.join(targetPath, 'node_modules'), 'junction', () => {});
+		fs.symlink(path.join(packagePath, 'package.json'), path.join(targetPath, 'package.json'), 'file', () => {});
 
-		execa.shell('npm link', { cwd: targetPath })
+		execa
+			.shell('npm link', { cwd: targetPath })
 			.then((result: any) => grunt.log.ok(result.stdout))
 			.then(done);
 	});
 
-	grunt.registerTask('link', 'link', function () {
+	grunt.registerTask('link', 'link', function() {
 		const targetPath = grunt.config('distDirectory');
 		const dirExists = grunt.file.isDir(targetPath);
 		const tasks = ['_link'];

--- a/tasks/postcss.ts
+++ b/tasks/postcss.ts
@@ -21,20 +21,24 @@ export = function init(grunt: IGrunt, packageJson: any) {
 	];
 
 	function moduleFiles(dest: string) {
-		return [{
-			expand: true,
-			src: ['**/*.m.css'],
-			dest: dest,
-			cwd: 'src'
-		}];
+		return [
+			{
+				expand: true,
+				src: ['**/*.m.css'],
+				dest: dest,
+				cwd: 'src'
+			}
+		];
 	}
 
-	const cssFiles = [{
-		expand: true,
-		src: ['**/*.css', '!**/*.m.css'],
-		dest: distDirectory,
-		cwd: 'src'
-	}];
+	const cssFiles = [
+		{
+			expand: true,
+			src: ['**/*.css', '!**/*.m.css'],
+			dest: distDirectory,
+			cwd: 'src'
+		}
+	];
 
 	grunt.config.set('postcss', {
 		options: {

--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -54,7 +54,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 		return packageJson;
 	}
 
-	function getGitRemote(): string|boolean {
+	function getGitRemote(): string | boolean {
 		const gitConfig = parse.sync();
 		const remotes = Object.keys(gitConfig)
 			.filter((key) => key.indexOf('remote') === 0)
@@ -90,7 +90,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 		return Promise.resolve({});
 	}
 
-	grunt.registerTask('can-publish-check', 'check whether author can publish', function (this: ITask) {
+	grunt.registerTask('can-publish-check', 'check whether author can publish', function(this: ITask) {
 		const done = this.async();
 		const whoamiPromise = command(npmBin, ['whoami'], {}, true).then(
 			(result: any) => result.stdout,
@@ -101,21 +101,23 @@ export = function(grunt: IGrunt, packageJson: any) {
 			maintainersPromise = Promise.resolve(defaultMaintainers);
 		} else {
 			maintainersPromise = command(npmBin, ['view', '.', '--json'], {}, true)
-				.then((result: any) => <string[]> JSON.parse(result.stdout).maintainers)
+				.then((result: any) => <string[]>JSON.parse(result.stdout).maintainers)
 				.then((maintainers: string[]) => maintainers.map((maintainer) => maintainer.replace(/\s<.*/, '')));
 		}
 
-		return Promise.all([whoamiPromise, maintainersPromise]).then((results) => {
-			const user = results[0];
-			const maintainers = results[1];
-			const isMaintainer = maintainers.indexOf(user) > -1;
-			if (!isMaintainer) {
-				grunt.fail.fatal(`cannot publish this package with user ${user}`);
-			}
-		}).then(done);
+		return Promise.all([whoamiPromise, maintainersPromise])
+			.then((results) => {
+				const user = results[0];
+				const maintainers = results[1];
+				const isMaintainer = maintainers.indexOf(user) > -1;
+				if (!isMaintainer) {
+					grunt.fail.fatal(`cannot publish this package with user ${user}`);
+				}
+			})
+			.then(done);
 	});
 
-	grunt.registerTask('repo-is-clean-check', 'check whether the repo is clean', function (this: ITask) {
+	grunt.registerTask('repo-is-clean-check', 'check whether the repo is clean', function(this: ITask) {
 		const done = this.async();
 		return command(gitBin, ['status', '--porcelain'], {}, true)
 			.then((result: any) => {
@@ -132,7 +134,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 			.then(done);
 	});
 
-	grunt.registerTask('release-publish', 'publish the package to npm', function (this: ITask) {
+	grunt.registerTask('release-publish', 'publish the package to npm', function(this: ITask) {
 		const done = this.async();
 		const args = ['publish', '.'];
 		if (tag) {
@@ -146,7 +148,9 @@ export = function(grunt: IGrunt, packageJson: any) {
 		return Promise.all(promises).then(done);
 	});
 
-	grunt.registerTask('release-version-pre-release-tag', 'auto version based on pre release tag', function (this: ITask) {
+	grunt.registerTask('release-version-pre-release-tag', 'auto version based on pre release tag', function(
+		this: ITask
+	) {
 		const done = this.async();
 		const versionInPackage = initialPackageJson.version.replace(/-.*/g, '');
 		if (initial) {
@@ -166,7 +170,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 		}
 	});
 
-	grunt.registerTask('release-version-specific', 'set the version manually', function (this: ITask) {
+	grunt.registerTask('release-version-specific', 'set the version manually', function(this: ITask) {
 		const done = this.async();
 		const args = ['version', releaseVersion];
 		if (dryRun) {
@@ -176,7 +180,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 		return command(npmBin, args, {}, true).then(done);
 	});
 
-	grunt.registerTask('post-release-version', 'update the version post release', function (this: ITask) {
+	grunt.registerTask('post-release-version', 'update the version post release', function(this: ITask) {
 		const done = this.async();
 		const packageJson = Object.assign({}, initialPackageJson);
 		if (nextVersion) {
@@ -191,8 +195,9 @@ export = function(grunt: IGrunt, packageJson: any) {
 				}
 				const remote = getGitRemote();
 				if (remote) {
-					return command(gitBin, ['push', <string> remote, defaultBranch], {}, false)
-						.then(() => command(gitBin, ['push', <string> remote, '--tags'], {}, false));
+					return command(gitBin, ['push', <string>remote, defaultBranch], {}, false).then(() =>
+						command(gitBin, ['push', <string>remote, '--tags'], {}, false)
+					);
 				} else {
 					grunt.log.subhead('could not find remote to push back to. please push with tags back to remote');
 				}
@@ -201,7 +206,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 			.then(done);
 	});
 
-	grunt.registerTask('release-publish-flat', 'publish the flat package', function () {
+	grunt.registerTask('release-publish-flat', 'publish the flat package', function() {
 		grunt.log.subhead('making flat package...');
 		const pkg = grunt.file.readJSON(path.join(packagePath, 'package.json'));
 		const dist = grunt.config('copy.staticDefinitionFiles-dist.dest');
@@ -209,7 +214,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 
 		grunt.config.merge({
 			copy: { temp: { expand: true, cwd: dist, src: '**', dest: temp } },
-			clean: { temp: [ temp ] }
+			clean: { temp: [temp] }
 		});
 
 		grunt.file.write(path.join(temp, 'package.json'), JSON.stringify(preparePackageJson(pkg), null, '  ') + '\n');
@@ -224,7 +229,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 
 	grunt.registerTask('customise-dist-output', () => {});
 
-	grunt.registerTask('release', 'release', function () {
+	grunt.registerTask('release', 'release', function() {
 		grunt.option('remove-links', true);
 		const tasks = ['dist'];
 

--- a/tasks/rename.ts
+++ b/tasks/rename.ts
@@ -2,14 +2,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 import IMultiTask = grunt.task.IMultiTask;
 
-export = function (grunt: IGrunt) {
-	grunt.registerMultiTask('rename', function (this: IMultiTask<void>) {
-		this.files.forEach(function (file) {
+export = function(grunt: IGrunt) {
+	grunt.registerMultiTask('rename', function(this: IMultiTask<void>) {
+		this.files.forEach(function(file) {
 			if (grunt.file.isFile(file.src![0])) {
 				grunt.file.mkdir(path.dirname(file.dest!));
 			}
 			fs.renameSync(file.src![0], file.dest!);
-			(<any> grunt)['verbose'].writeln('Renamed ' + file.src![0] + ' to ' + file.dest);
+			(<any>grunt)['verbose'].writeln('Renamed ' + file.src![0] + ' to ' + file.dest);
 		});
 		grunt.log.writeln('Moved ' + this.files.length + ' files');
 	});

--- a/tasks/repl.ts
+++ b/tasks/repl.ts
@@ -7,26 +7,26 @@ import loadDojoLoader from '../lib/load-dojo-loader';
 const resolveFrom = require('resolve-from');
 
 export = function(grunt: IGrunt, packageJson: any) {
-	grunt.registerTask('repl', 'Bootstrap dojo-loader and start a Node.js REPL', function (this: ITask) {
+	grunt.registerTask('repl', 'Bootstrap dojo-loader and start a Node.js REPL', function(this: ITask) {
 		this.async(); // Ensure Grunt doesn't exit the process.
 
 		const { baseUrl, packages, require: dojoRequire } = loadDojoLoader(packageJson);
 
-		const nodeRequire = function (mid: string) {
+		const nodeRequire = function(mid: string) {
 			// Require relative to the baseUrl, not this module.
 			return require(resolveFrom(baseUrl, mid));
 		};
 		Object.defineProperty(nodeRequire, 'resolve', {
 			configurable: false,
 			enumerable: true,
-			value (mid: string) {
+			value(mid: string) {
 				return resolveFrom(baseUrl, mid);
 			}
 		});
 
 		grunt.log.ok(`Available packages: ${packages.map(({ name }) => name).join(', ')}`);
 		grunt.log.ok('require() is now powered by dojo-loader');
-		grunt.log.ok('Node.js\' require() is available under nodeRequire()');
+		grunt.log.ok("Node.js' require() is available under nodeRequire()");
 
 		const { context } = repl.start();
 		Object.defineProperties(context, {

--- a/tasks/run.ts
+++ b/tasks/run.ts
@@ -2,10 +2,10 @@ import loadDojoLoader from '../lib/load-dojo-loader';
 import ITask = grunt.task.ITask;
 
 export = function(grunt: IGrunt, packageJson: any) {
-	grunt.registerTask('run', 'Bootstrap dojo-loader and run the given --main', function (this: ITask) {
+	grunt.registerTask('run', 'Bootstrap dojo-loader and run the given --main', function(this: ITask) {
 		this.async(); // Ensure Grunt doesn't exit the process.
 
-		const main = <string> grunt.option('main') || 'src/main';
+		const main = <string>grunt.option('main') || 'src/main';
 		grunt.log.ok(main);
 
 		const { require } = loadDojoLoader(packageJson);

--- a/tasks/tcm.ts
+++ b/tasks/tcm.ts
@@ -2,11 +2,11 @@ import * as glob from 'glob';
 import * as DtsCreator from 'typed-css-modules';
 import ITask = grunt.task.ITask;
 export = function(grunt: IGrunt) {
-	grunt.registerTask('tcm', 'generate css modules', function (this: ITask) {
+	grunt.registerTask('tcm', 'generate css modules', function(this: ITask) {
 		const done = this.async();
 		const creator = new DtsCreator({
 			rootDir: process.cwd(),
-			searchDir: 'src',
+			searchDir: 'src'
 		});
 
 		glob('src/**/*.m.css', (error: Error | null, files: string[]) => {
@@ -15,10 +15,10 @@ export = function(grunt: IGrunt) {
 				return;
 			}
 
-			Promise.all(files.map(file => creator.create(file)))
-				.then(dtsFilesContents => Promise.all(
-					dtsFilesContents.map(dtsFileContents => dtsFileContents.writeFile())
-				))
+			Promise.all(files.map((file) => creator.create(file)))
+				.then((dtsFilesContents) =>
+					Promise.all(dtsFilesContents.map((dtsFileContents) => dtsFileContents.writeFile()))
+				)
 				.then(done, done);
 		});
 	});

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -4,7 +4,7 @@ import ITask = grunt.task.ITask;
 
 const excludes = ['tests/**/*.ts', 'tests/**/*.tsx', 'src/*/tests/**/*.ts', 'src/*/example/**/*.ts'];
 
-export = function (grunt: IGrunt) {
+export = function(grunt: IGrunt) {
 	const distDirectory = grunt.config.get<string>('distDirectory');
 	const defaultOptions: any = {
 		umd: {
@@ -29,42 +29,42 @@ export = function (grunt: IGrunt) {
 	};
 	const postTasks: any = {
 		esm: [
-			function () {
+			function() {
 				grunt.task.registerTask('rename-mjs', () => {
 					// rename .js files to .mjs files
-					grunt.file.expand(['dist/esm/**/*.js'])
-						.forEach(file => fs.renameSync(file, file.replace(/\.js$/g, '.mjs')));
+					grunt.file
+						.expand(['dist/esm/**/*.js'])
+						.forEach((file) => fs.renameSync(file, file.replace(/\.js$/g, '.mjs')));
 
 					// rename .js.map files to .mjs.map files
-					grunt.file.expand(['dist/esm/**/*.js.map'])
-						.forEach(file => fs.renameSync(file, file.replace(/\.js\.map$/g, '.mjs.map')));
+					grunt.file
+						.expand(['dist/esm/**/*.js.map'])
+						.forEach((file) => fs.renameSync(file, file.replace(/\.js\.map$/g, '.mjs.map')));
 
 					// fix the source map comments in the .mjs files
-					grunt.file.expand(['dist/esm/**/*.mjs'])
-						.forEach(file => {
-							let contents = grunt.file.read(file);
+					grunt.file.expand(['dist/esm/**/*.mjs']).forEach((file) => {
+						let contents = grunt.file.read(file);
 
-							contents = contents.replace(/(\/\/.*sourceMappingURL=.*?)(\.js\.map)/g, '$1.mjs.map');
+						contents = contents.replace(/(\/\/.*sourceMappingURL=.*?)(\.js\.map)/g, '$1.mjs.map');
 
-							grunt.file.write(file, contents);
-						});
+						grunt.file.write(file, contents);
+					});
 
 					// change the .js files to .mjs files inside the map files
-					grunt.file.expand(['dist/esm/**/*.mjs.map'])
-						.forEach(file => {
-							const json = grunt.file.readJSON(file);
-							if (json.file) {
-								json.file = json.file.replace(/\.js$/g, '.mjs');
-							}
+					grunt.file.expand(['dist/esm/**/*.mjs.map']).forEach((file) => {
+						const json = grunt.file.readJSON(file);
+						if (json.file) {
+							json.file = json.file.replace(/\.js$/g, '.mjs');
+						}
 
-							grunt.file.write(file, JSON.stringify(json));
-						});
+						grunt.file.write(file, JSON.stringify(json));
+					});
 				});
 				return 'rename-mjs';
 			}
 		],
 		dist: [
-			function () {
+			function() {
 				grunt.task.registerTask('merge-dist', () => {
 					grunt.file.expand(['dist/umd/**/*']).forEach((file: string) => {
 						grunt.file.copy(file, file.replace('dist/umd/', distDirectory));
@@ -80,7 +80,7 @@ export = function (grunt: IGrunt) {
 		]
 	};
 
-	grunt.registerTask('dojo-ts', <any> function (this: ITask) {
+	grunt.registerTask('dojo-ts', <any>function(this: ITask) {
 		grunt.loadNpmTasks('grunt-ts');
 
 		const flags = this.args && this.args.length ? this.args : ['dev'];

--- a/tasks/typed-css-modules.d.ts
+++ b/tasks/typed-css-modules.d.ts
@@ -10,17 +10,14 @@ declare module 'typed-css-modules/index' {
 	}
 
 	class DtsCreator {
-		constructor(options?: {
-			rootDir?: string;
-			searchDir?: string;
-			outDir?: string;
-			camelCase?: boolean;
-		});
+		constructor(options?: { rootDir?: string; searchDir?: string; outDir?: string; camelCase?: boolean });
 
 		create(filePath: string, contents?: string): Promise<DtsContent>;
 	}
 
-	namespace DtsCreator { }
+	namespace DtsCreator {
+
+	}
 
 	export = DtsCreator;
 }

--- a/tasks/typedoc.ts
+++ b/tasks/typedoc.ts
@@ -12,47 +12,54 @@ import { existsSync } from 'fs';
  */
 function typedocOptions(options: any) {
 	const args: string[] = [];
-	Object.keys(options).filter(key => {
-		return key !== 'publishOptions';
-	}).forEach(key => {
-		if (options[key]) {
-			args.push(`--${key}`);
+	Object.keys(options)
+		.filter((key) => {
+			return key !== 'publishOptions';
+		})
+		.forEach((key) => {
+			if (options[key]) {
+				args.push(`--${key}`);
 
-			if (typeof options[key] !== 'boolean') {
-				args.push(`"${options[key]}"`);
+				if (typeof options[key] !== 'boolean') {
+					args.push(`"${options[key]}"`);
+				}
 			}
-		}
-	});
+		});
 	return args;
 }
 
-export = function (grunt: IGrunt) {
-	grunt.registerTask('typedoc', function (this: ITask) {
+export = function(grunt: IGrunt) {
+	grunt.registerTask('typedoc', function(this: ITask) {
 		// Throw when any shelljs command fails
 		config.fatal = true;
 
 		const options: any = this.options({});
-		const publishOptions = Object.assign({
-			log: grunt.log,
-			subDirectory: ''
-		}, options.publishOptions || {});
+		const publishOptions = Object.assign(
+			{
+				log: grunt.log,
+				subDirectory: ''
+			},
+			options.publishOptions || {}
+		);
 		options.out = grunt.option<string>('doc-dir') || options.out || grunt.config.get<string>('apiDocDirectory');
 
 		// Use project-local typedoc
 		const typedoc = require.resolve('typedoc/bin/typedoc');
-		grunt.log.writeln(`Building API Docs to "${ options.out }"`);
-		exec(`node "${ typedoc }" ${ typedocOptions(options).join(' ') }`);
+		grunt.log.writeln(`Building API Docs to "${options.out}"`);
+		exec(`node "${typedoc}" ${typedocOptions(options).join(' ')}`);
 
 		// Publish
-		const publishMode = (typeof publishOptions.publishMode === 'function') ? publishOptions.publishMode() :
-			publishOptions.publishMode;
+		const publishMode =
+			typeof publishOptions.publishMode === 'function'
+				? publishOptions.publishMode()
+				: publishOptions.publishMode;
 		if (publishMode) {
 			const cloneDir = grunt.config.get<string>('apiPubDirectory');
 			const publisher = new Publisher(cloneDir, publishOptions);
 			publisher.init();
 
 			const apiDocTarget = join(cloneDir, publishOptions.subDirectory);
-			grunt.log.writeln(`copying ${ options.out } to ${ apiDocTarget }`);
+			grunt.log.writeln(`copying ${options.out} to ${apiDocTarget}`);
 			rm('-rf', apiDocTarget);
 			cp('-r', options.out, apiDocTarget);
 
@@ -66,8 +73,7 @@ export = function (grunt: IGrunt) {
 			if (publisher.commit()) {
 				if (publishMode === 'publish') {
 					publisher.publish();
-				}
-				else {
+				} else {
 					grunt.log.writeln('Only committing -- skipping push to repo');
 				}
 			}

--- a/tasks/uploadCoverage.ts
+++ b/tasks/uploadCoverage.ts
@@ -1,12 +1,12 @@
 import ITask = grunt.task.ITask;
 const sendToCodeCov = require('codecov.io/lib/sendToCodeCov.io');
 
-export = function (grunt: IGrunt) {
-	grunt.registerTask('uploadCoverage', <any> function (this: ITask) {
+export = function(grunt: IGrunt) {
+	grunt.registerTask('uploadCoverage', <any>function(this: ITask) {
 		const done = this.async();
 
 		const contents = grunt.file.read('coverage-final.lcov');
-		sendToCodeCov(contents, function (err: Error) {
+		sendToCodeCov(contents, function(err: Error) {
 			done(err);
 		});
 	});

--- a/tasks/util/Publisher.ts
+++ b/tasks/util/Publisher.ts
@@ -22,7 +22,7 @@ const consoleLogger = {
 };
 
 export function setGlobalConfig(key: string, value: string) {
-	return exec(`git config --global ${ key } ${ value }`, { silent: true });
+	return exec(`git config --global ${key} ${value}`, { silent: true });
 }
 
 export default class Publisher {
@@ -60,10 +60,9 @@ export default class Publisher {
 		options.log && (this.log = options.log);
 		if (options.url) {
 			this.url = options.url;
-		}
-		else {
+		} else {
 			const repo = process.env.TRAVIS_REPO_SLUG || ''; // TODO look up the repo information?
-			this.url = `git@github.com:${ repo }.git`;
+			this.url = `git@github.com:${repo}.git`;
 		}
 	}
 
@@ -102,15 +101,14 @@ export default class Publisher {
 			setGlobalConfig('user.email', 'support@sitepen.com');
 		}
 
-		this.log.writeln(`Cloning ${ this.url }`);
-		this.execSSHAgent('git', [ 'clone', this.url, this.cloneDirectory ], { silent: true });
+		this.log.writeln(`Cloning ${this.url}`);
+		this.execSSHAgent('git', ['clone', this.url, this.cloneDirectory], { silent: true });
 
 		try {
-			exec(`git checkout ${ publishBranch }`, { silent: true, cwd: this.cloneDirectory });
-		}
-		catch (error) {
+			exec(`git checkout ${publishBranch}`, { silent: true, cwd: this.cloneDirectory });
+		} catch (error) {
 			// publish branch didn't exist, so create it
-			exec(`git checkout --orphan ${ publishBranch }`, { silent: true, cwd: this.cloneDirectory });
+			exec(`git checkout --orphan ${publishBranch}`, { silent: true, cwd: this.cloneDirectory });
 			exec('git rm -rf .', { silent: true, cwd: this.cloneDirectory });
 			this.log.writeln(`Created ${publishBranch} branch`);
 		}
@@ -122,7 +120,7 @@ export default class Publisher {
 	 */
 	publish() {
 		this.log.writeln(`Publishing ${this.branch} to origin`);
-		this.execSSHAgent('git', [ 'push', 'origin', this.branch ], { silent: true, cwd: this.cloneDirectory });
+		this.execSSHAgent('git', ['push', 'origin', this.branch], { silent: true, cwd: this.cloneDirectory });
 		this.log.writeln(`Pushed ${this.branch} to origin`);
 	}
 
@@ -133,13 +131,12 @@ export default class Publisher {
 	 */
 	private execSSHAgent(command: string, args: string[], options: any): string {
 		if (this.hasDeployCredentials()) {
-			const deployKey: string = <string> this.deployKey;
+			const deployKey: string = <string>this.deployKey;
 			const relativeDeployKey = options.cwd ? relative(options.cwd, deployKey) : deployKey;
 			chmodSync(deployKey, '600');
-			return exec(`ssh-agent bash -c 'ssh-add ${ relativeDeployKey }; ${ command } ${ args.join(' ') }'`, options);
-		}
-		else {
-			this.log.writeln(`Deploy Key "${ this.deployKey }" is not present. Using environment credentials.`);
+			return exec(`ssh-agent bash -c 'ssh-add ${relativeDeployKey}; ${command} ${args.join(' ')}'`, options);
+		} else {
+			this.log.writeln(`Deploy Key "${this.deployKey}" is not present. Using environment credentials.`);
 			const response = spawn(command, args, options);
 
 			if (response.stderr) {
@@ -151,9 +148,8 @@ export default class Publisher {
 
 	private hasConifg(key: string): boolean {
 		try {
-			return !!exec(`git config ${ key }`, { silent: true });
-		}
-		catch (e) { }
+			return !!exec(`git config ${key}`, { silent: true });
+		} catch (e) {}
 
 		return false;
 	}

--- a/tasks/util/postcss.ts
+++ b/tasks/util/postcss.ts
@@ -12,20 +12,17 @@ export function createProcessors({
 	dist,
 	packageJson
 }: {
-		dest: string,
-		cwd?: string,
-		dist?: boolean,
-		packageJson: any
+	dest: string;
+	cwd?: string;
+	dist?: boolean;
+	packageJson: any;
 }) {
 	return [
 		postCssImport,
 		postCssNext({
 			features: {
 				autoprefixer: {
-					browsers: [
-						'last 2 versions',
-						'ie >= 11'
-					]
+					browsers: ['last 2 versions', 'ie >= 11']
 				}
 			}
 		}),

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -1,9 +1,7 @@
 import 'intern';
 
 export const loaderOptions = {
-	packages: [
-		{name: 'grunt-dojo2', location: '.'}
-	]
+	packages: [{ name: 'grunt-dojo2', location: '.' }]
 };
 
 export const suites = ['grunt-dojo2/tests/unit/all'];

--- a/tests/unit/lib/internLoader.ts
+++ b/tests/unit/lib/internLoader.ts
@@ -26,7 +26,7 @@ const instrumentedCode = instrumenter.instrumentSync(loaderCode, sourceFile);
 
 function reportCoverage() {
 	intern.emit('coverage', {
-		coverage: (<any> context)['__coverage__'],
+		coverage: (<any>context)['__coverage__'],
 		source: '',
 		sessionId: intern.config.sessionId
 	});
@@ -49,7 +49,6 @@ function runTest(before: Function, after: Function) {
 				after();
 				resolve();
 			}, 100);
-
 		}
 	});
 }
@@ -58,7 +57,7 @@ registerSuite('lib/intern/internLoader', {
 	beforeEach() {
 		sandbox = sinon.sandbox.create();
 		requireMock = sandbox.stub().callsArg(1);
-		(<any> requireMock).config = sandbox.stub();
+		(<any>requireMock).config = sandbox.stub();
 
 		loaderPromise = undefined;
 
@@ -87,52 +86,66 @@ registerSuite('lib/intern/internLoader', {
 	},
 	tests: {
 		async 'registers the intern loader'() {
-			return runTest(() => {
-				sandbox.stub(internMock, 'registerLoader');
-			}, () => {
-				assert.isTrue(internMock.registerLoader.called);
-			});
+			return runTest(
+				() => {
+					sandbox.stub(internMock, 'registerLoader');
+				},
+				() => {
+					assert.isTrue(internMock.registerLoader.called);
+				}
+			);
 		},
 
 		async 'loads the AMD util'() {
-			return runTest(() => {
-			}, () => {
-				assert.isTrue(internMock.loadScript.calledWith('node_modules/@dojo/loader/loader.js'));
-				assert.isTrue(internMock.loadScript.calledWith('node_modules/@dojo/shim/util/amd.js'));
-			});
+			return runTest(
+				() => {},
+				() => {
+					assert.isTrue(internMock.loadScript.calledWith('node_modules/@dojo/loader/loader.js'));
+					assert.isTrue(internMock.loadScript.calledWith('node_modules/@dojo/shim/util/amd.js'));
+				}
+			);
 		},
 
 		async 'configures the loader with the baseurl from options'() {
-			return runTest(() => {
-			}, () => {
-				assert.equal(requireMock.config.args[0][0].baseUrl, '/options');
-			});
+			return runTest(
+				() => {},
+				() => {
+					assert.equal(requireMock.config.args[0][0].baseUrl, '/options');
+				}
+			);
 		},
 
 		async 'configures the loader with the baseurl from config'() {
-			return runTest(() => {
-				sandbox.stub(internMock, 'registerLoader').callsArgWith(0, {});
-			}, () => {
-				assert.equal(requireMock.config.args[0][0].baseUrl, '/config');
-			});
+			return runTest(
+				() => {
+					sandbox.stub(internMock, 'registerLoader').callsArgWith(0, {});
+				},
+				() => {
+					assert.equal(requireMock.config.args[0][0].baseUrl, '/config');
+				}
+			);
 		},
 
 		async 'loads shim/main'() {
-			return runTest(() => {
-			}, () => {
-				assert.equal(requireMock.args[0][0], '@dojo/shim/main');
-			});
+			return runTest(
+				() => {},
+				() => {
+					assert.equal(requireMock.args[0][0], '@dojo/shim/main');
+				}
+			);
 		},
 
 		async 'creates a loader that uses require'() {
 			return new Promise((resolve) => {
-				runTest(() => {
-				}, (result: any) => {
-					result(['some-module']).then(() => {
-						assert.isTrue(requireMock.calledWith(['some-module']));
-						resolve();
-					});
-				});
+				runTest(
+					() => {},
+					(result: any) => {
+						result(['some-module']).then(() => {
+							assert.isTrue(requireMock.calledWith(['some-module']));
+							resolve();
+						});
+					}
+				);
 			});
 		}
 	}

--- a/tests/unit/lib/load-dojo-loader.ts
+++ b/tests/unit/lib/load-dojo-loader.ts
@@ -6,33 +6,32 @@ const { assert } = intern.getPlugin('chai');
 import * as mockery from 'mockery';
 
 registerSuite('lib/load-dojo-loader', {
-	before: function () {
+	before: function() {
 		mockery.enable({
 			warnOnReplace: false,
 			warnOnUnregistered: false,
 			useCleanCache: true
 		});
 	},
-	after: function () {
+	after: function() {
 		mockery.disable();
 	},
 
 	tests: {
-		run: function () {
-			mockery.registerMock('resolve-from', function (baseUrl: string, mid: string) {
+		run: function() {
+			mockery.registerMock('resolve-from', function(baseUrl: string, mid: string) {
 				return '/' + mid;
 			});
 
 			let configBaseUrl: string = '';
 			let configPackages: {
-				name: string,
-				location: string
+				name: string;
+				location: string;
 			}[] = [];
 
 			let fakeRequire = {
-				require: function () {
-				},
-				config: function (obj: any) {
+				require: function() {},
+				config: function(obj: any) {
 					configBaseUrl = obj.baseUrl;
 					configPackages = obj.packages;
 				}
@@ -44,11 +43,11 @@ registerSuite('lib/load-dojo-loader', {
 
 			let result = loader({
 				peerDependencies: {
-					'test': 'test',
+					test: 'test',
 					'dojo-loader': 'dojo-loader',
 					'@reactivex/rxjs': true,
-					'maquette': true,
-					'immutable': true
+					maquette: true,
+					immutable: true
 				}
 			});
 

--- a/tests/unit/options/intern.ts
+++ b/tests/unit/options/intern.ts
@@ -17,22 +17,17 @@ registerSuite('options/intern', {
 		delete require.cache[require.resolve('../../../options/intern')];
 	},
 	tests: {
-		'defaults'() {
+		defaults() {
 			const config = require('../../../options/intern')({
 				...grunt,
-				loadNpmTasks() {
-				}
+				loadNpmTasks() {}
 			});
 			assert.deepEqual(config, {
 				options: {
 					config: '<%= internConfig %>',
 					node: {
-						'plugins+': [
-							{ script: 'grunt-dojo2/lib/intern/Reporter.js', useLoader: true }
-						],
-						reporters: [
-							{ name: 'runner', options: { 'hideSkipped': true, 'hidePassed': true } }
-						]
+						'plugins+': [{ script: 'grunt-dojo2/lib/intern/Reporter.js', useLoader: true }],
+						reporters: [{ name: 'runner', options: { hideSkipped: true, hidePassed: true } }]
 					}
 				},
 				browserstack: {
@@ -64,11 +59,10 @@ registerSuite('options/intern', {
 				}
 			});
 		},
-		'progress'() {
+		progress() {
 			const config = require('../../../options/intern')({
 				...grunt,
-				loadNpmTasks() {
-				},
+				loadNpmTasks() {},
 				option(name: string) {
 					if (name === 'progress') {
 						return true;
@@ -79,12 +73,8 @@ registerSuite('options/intern', {
 				options: {
 					config: '<%= internConfig %>',
 					node: {
-						'plugins+': [
-							{ script: 'grunt-dojo2/lib/intern/Reporter.js', useLoader: true }
-						],
-						reporters: [
-							{ name: 'runner', options: { 'hideSkipped': false, 'hidePassed': false } }
-						]
+						'plugins+': [{ script: 'grunt-dojo2/lib/intern/Reporter.js', useLoader: true }],
+						reporters: [{ name: 'runner', options: { hideSkipped: false, hidePassed: false } }]
 					}
 				},
 				browserstack: {

--- a/tests/unit/tasks/fixSourceMaps.ts
+++ b/tests/unit/tasks/fixSourceMaps.ts
@@ -3,8 +3,14 @@ const { assert } = intern.getPlugin('chai');
 
 import * as grunt from 'grunt';
 import {
-	getInputDirectory, loadTasks, prepareInputDirectory, unloadTasks, cleanInputDirectory,
-	createDummyFile, runGruntTask, fileExistsInInputDirectory
+	getInputDirectory,
+	loadTasks,
+	prepareInputDirectory,
+	unloadTasks,
+	cleanInputDirectory,
+	createDummyFile,
+	runGruntTask,
+	fileExistsInInputDirectory
 } from '../util';
 
 const inputDirectory = getInputDirectory();
@@ -25,15 +31,16 @@ registerSuite('tasks/fixSourceMaps', {
 
 	tests: {
 		sourceMaps() {
-			createDummyFile('test/sourcemap.js.map', JSON.stringify(
-				{
-					'version': 3,
-					'file': 'global.js',
-					'sourceRoot': '',
-					'sources': [ '../../src/global.ts' ],
-					'names': []
-				}
-			));
+			createDummyFile(
+				'test/sourcemap.js.map',
+				JSON.stringify({
+					version: 3,
+					file: 'global.js',
+					sourceRoot: '',
+					sources: ['../../src/global.ts'],
+					names: []
+				})
+			);
 
 			runGruntTask('fixSourceMaps');
 
@@ -42,11 +49,11 @@ registerSuite('tasks/fixSourceMaps', {
 			const sourceMap = grunt.file.readJSON(inputDirectory + '/test/sourcemap.js.map');
 
 			assert.deepEqual(sourceMap, {
-				'version': 3,
-				'file': 'global.js',
-				'sourceRoot': '',
-				'sources': [ 'global.ts' ],
-				'names': []
+				version: 3,
+				file: 'global.js',
+				sourceRoot: '',
+				sources: ['global.ts'],
+				names: []
 			});
 		}
 	}

--- a/tests/unit/tasks/installPeerDependencies.ts
+++ b/tests/unit/tasks/installPeerDependencies.ts
@@ -17,7 +17,7 @@ registerSuite('tasks/installPeerDependencies', {
 		unloadTasks();
 	},
 	tests: {
-		'npm': {
+		npm: {
 			beforeEach() {
 				grunt.initConfig({});
 				mockErrorLogger = stub(grunt.log, 'error');
@@ -25,20 +25,25 @@ registerSuite('tasks/installPeerDependencies', {
 				mockShell = stub();
 
 				mockShell
-				.withArgs('npm install my-dep@"1.0" --no-save').returns(Promise.resolve({}))
-				.withArgs('npm install my-dep@"1.0" error-dep@"1.0" --no-save').throws();
+					.withArgs('npm install my-dep@"1.0" --no-save')
+					.returns(Promise.resolve({}))
+					.withArgs('npm install my-dep@"1.0" error-dep@"1.0" --no-save')
+					.throws();
 			},
 			tests: {
 				'sucessfully install peer dependencies'() {
-					loadTasks({
-						child_process: {
-							execSync: mockShell
+					loadTasks(
+						{
+							child_process: {
+								execSync: mockShell
+							}
+						},
+						{
+							peerDependencies: {
+								'my-dep': '1.0'
+							}
 						}
-					}, {
-						peerDependencies: {
-							'my-dep': '1.0'
-						}
-					});
+					);
 					runGruntTask('peerDepInstall');
 
 					assert.isTrue(mockShell.calledOnce);
@@ -47,16 +52,19 @@ registerSuite('tasks/installPeerDependencies', {
 					assert.isTrue(mockErrorLogger.notCalled);
 				},
 				'fail to install peer dependencies'() {
-					loadTasks({
-						child_process: {
-							execSync: mockShell
+					loadTasks(
+						{
+							child_process: {
+								execSync: mockShell
+							}
+						},
+						{
+							peerDependencies: {
+								'my-dep': '1.0',
+								'error-dep': '1.0'
+							}
 						}
-					}, {
-						peerDependencies: {
-							'my-dep': '1.0',
-							'error-dep': '1.0'
-						}
-					});
+					);
 					runGruntTask('peerDepInstall');
 
 					assert.isTrue(mockShell.calledOnce);
@@ -65,14 +73,16 @@ registerSuite('tasks/installPeerDependencies', {
 					assert.isTrue(mockErrorLogger.calledWith('failed.'));
 				},
 				'no peer deps found'() {
-					loadTasks({
-						child_process: {
-							execSync: mockShell
+					loadTasks(
+						{
+							child_process: {
+								execSync: mockShell
+							}
+						},
+						{
+							peerDependencies: {}
 						}
-					}, {
-						peerDependencies: {
-						}
-					});
+					);
 					runGruntTask('peerDepInstall');
 
 					assert.isTrue(mockShell.notCalled);

--- a/tests/unit/tasks/link.ts
+++ b/tests/unit/tasks/link.ts
@@ -6,7 +6,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { SinonStub, stub } from 'sinon';
 import {
-	getOutputDirectory, loadTasks, unloadTasks, runGruntTask, prepareOutputDirectory,
+	getOutputDirectory,
+	loadTasks,
+	unloadTasks,
+	runGruntTask,
+	prepareOutputDirectory,
 	cleanOutputDirectory
 } from '../util';
 
@@ -25,16 +29,15 @@ registerSuite('tasks/link', {
 
 		symlink = stub(fs, 'symlink');
 
-		shell.withArgs(
-			'npm link',
-			{
+		shell
+			.withArgs('npm link', {
 				cwd: outputPath
-			}
-		).returns(
-			Promise.resolve({
-				stdout: ''
 			})
-		);
+			.returns(
+				Promise.resolve({
+					stdout: ''
+				})
+			);
 
 		loadTasks({
 			fs: fs,
@@ -58,8 +61,20 @@ registerSuite('tasks/link', {
 			runGruntTask('_link');
 
 			assert.isTrue(symlink.calledTwice);
-			assert.isTrue(symlink.firstCall.calledWith(path.join(cwd, 'node_modules'), path.join(outputPath, 'node_modules'), 'junction'));
-			assert.isTrue(symlink.secondCall.calledWith(path.join(cwd, 'package.json'), path.join(outputPath, 'package.json'), 'file'));
+			assert.isTrue(
+				symlink.firstCall.calledWith(
+					path.join(cwd, 'node_modules'),
+					path.join(outputPath, 'node_modules'),
+					'junction'
+				)
+			);
+			assert.isTrue(
+				symlink.secondCall.calledWith(
+					path.join(cwd, 'package.json'),
+					path.join(outputPath, 'package.json'),
+					'file'
+				)
+			);
 			assert.isTrue(shell.calledOnce);
 			assert.isTrue(shell.calledWith('npm link', { cwd: outputPath }));
 		},
@@ -81,7 +96,7 @@ registerSuite('tasks/link', {
 					cleanOutputDirectory();
 
 					assert.isTrue(run.calledOnce);
-					assert.deepEqual(run.firstCall.args[ 0 ], [ '_link' ]);
+					assert.deepEqual(run.firstCall.args[0], ['_link']);
 				},
 
 				withoutDir() {
@@ -90,7 +105,7 @@ registerSuite('tasks/link', {
 					runGruntTask('link');
 
 					assert.isTrue(run.calledOnce);
-					assert.deepEqual(run.firstCall.args[ 0 ], [ 'dist', '_link' ]);
+					assert.deepEqual(run.firstCall.args[0], ['dist', '_link']);
 				}
 			}
 		}

--- a/tests/unit/tasks/release.ts
+++ b/tests/unit/tasks/release.ts
@@ -14,17 +14,21 @@ let originalOptions: {
 
 const gitUrl = 'git@github.com:dojo/test';
 
-function taskLoader(config?: { [key: string]: any }, options?: { [key: string]: any }, mocks: { [key: string]: any } = {}) {
+function taskLoader(
+	config?: { [key: string]: any },
+	options?: { [key: string]: any },
+	mocks: { [key: string]: any } = {}
+) {
 	originalOptions = {};
 
 	if (options) {
 		Object.keys(options).forEach((option) => {
-			originalOptions[ option ] = grunt.option(option);
-			grunt.option(option, options[ option ]);
+			originalOptions[option] = grunt.option(option);
+			grunt.option(option, options[option]);
 		});
 	}
 
-	mocks[ 'execa' ] = {
+	mocks['execa'] = {
 		shell: shell
 	};
 
@@ -35,7 +39,7 @@ function taskLoader(config?: { [key: string]: any }, options?: { [key: string]: 
 
 function taskUnloader() {
 	Object.keys(originalOptions).forEach((option: string) => {
-		grunt.option(option, originalOptions[ option ]);
+		grunt.option(option, originalOptions[option]);
 	});
 
 	unloadTasks();
@@ -44,7 +48,7 @@ function taskUnloader() {
 let failureStub: SinonStub;
 
 registerSuite('tasks/release', {
-	'can-publish-check': (function (): ObjectSuiteDescriptor {
+	'can-publish-check': (function(): ObjectSuiteDescriptor {
 		let fail: SinonStub;
 
 		return {
@@ -64,22 +68,32 @@ registerSuite('tasks/release', {
 
 					taskLoader();
 
-					shell.withArgs('npm whoami')
+					shell
+						.withArgs('npm whoami')
 						.returns(Promise.reject(new Error()))
 						.withArgs('npm view . --json')
-						.returns(Promise.resolve(JSON.stringify({
-							maintainers: [
-								'dojotoolkit <kitsonk@dojotoolkit.org>',
-								'sitepen <labs@sitepen.com>'
-							]
-						})));
+						.returns(
+							Promise.resolve(
+								JSON.stringify({
+									maintainers: ['dojotoolkit <kitsonk@dojotoolkit.org>', 'sitepen <labs@sitepen.com>']
+								})
+							)
+						);
 
-					runGruntTask('can-publish-check', dfd.rejectOnError(() => {
-						assert(false, 'Should have failed');
-					})).catch(dfd.callback(() => {
-						assert.isTrue(fail.calledOnce, 'grunt.fail.fatal should have been called once');
-						assert.isTrue(fail.calledWith('not logged into npm'), 'grunt.fail.fatal should have been called with the error message');
-					}));
+					runGruntTask(
+						'can-publish-check',
+						dfd.rejectOnError(() => {
+							assert(false, 'Should have failed');
+						})
+					).catch(
+						dfd.callback(() => {
+							assert.isTrue(fail.calledOnce, 'grunt.fail.fatal should have been called once');
+							assert.isTrue(
+								fail.calledWith('not logged into npm'),
+								'grunt.fail.fatal should have been called with the error message'
+							);
+						})
+					);
 				},
 
 				'not a maintainer'() {
@@ -87,20 +101,32 @@ registerSuite('tasks/release', {
 
 					taskLoader();
 
-					shell.withArgs('npm whoami').returns(Promise.resolve({ stdout: 'test' })).withArgs('npm view . --json').returns(Promise.resolve({
-						stdout: JSON.stringify({
-							maintainers: [
-								'sitepen <labs@sitepen.com>'
-							]
-						})
-					}));
+					shell
+						.withArgs('npm whoami')
+						.returns(Promise.resolve({ stdout: 'test' }))
+						.withArgs('npm view . --json')
+						.returns(
+							Promise.resolve({
+								stdout: JSON.stringify({
+									maintainers: ['sitepen <labs@sitepen.com>']
+								})
+							})
+						);
 
-					runGruntTask('can-publish-check', dfd.rejectOnError(() => {
-						assert(false, 'Should have failed');
-					})).catch(dfd.callback((error: Error) => {
-						assert.isTrue(fail.calledOnce, 'grunt.fail.fatal should have been called once');
-						assert.isTrue(fail.calledWith('cannot publish this package with user test'), 'grunt.fail.fatal should have been called with the error message');
-					}));
+					runGruntTask(
+						'can-publish-check',
+						dfd.rejectOnError(() => {
+							assert(false, 'Should have failed');
+						})
+					).catch(
+						dfd.callback((error: Error) => {
+							assert.isTrue(fail.calledOnce, 'grunt.fail.fatal should have been called once');
+							assert.isTrue(
+								fail.calledWith('cannot publish this package with user test'),
+								'grunt.fail.fatal should have been called with the error message'
+							);
+						})
+					);
 				},
 
 				'dry run run commands anyways'() {
@@ -110,46 +136,62 @@ registerSuite('tasks/release', {
 						'dry-run': true
 					});
 
-					shell.withArgs('npm whoami')
+					shell
+						.withArgs('npm whoami')
 						.returns(Promise.reject(new Error()))
 						.withArgs('npm view . --json')
-						.returns(Promise.resolve(JSON.stringify({
-							maintainers: [
-								'dojotoolkit <kitsonk@dojotoolkit.org>',
-								'sitepen <labs@sitepen.com>'
-							]
-						})));
+						.returns(
+							Promise.resolve(
+								JSON.stringify({
+									maintainers: ['dojotoolkit <kitsonk@dojotoolkit.org>', 'sitepen <labs@sitepen.com>']
+								})
+							)
+						);
 
-					runGruntTask('can-publish-check', dfd.rejectOnError(() => {
-						assert(false, 'Should have failed');
-					})).catch(dfd.callback(() => {
-						assert.isTrue(fail.calledOnce, 'grunt.fail.fatal should have been called once');
-						assert.isTrue(fail.calledWith('not logged into npm'), 'grunt.fail.fatal should have been called with the error message');
-					}));
+					runGruntTask(
+						'can-publish-check',
+						dfd.rejectOnError(() => {
+							assert(false, 'Should have failed');
+						})
+					).catch(
+						dfd.callback(() => {
+							assert.isTrue(fail.calledOnce, 'grunt.fail.fatal should have been called once');
+							assert.isTrue(
+								fail.calledWith('not logged into npm'),
+								'grunt.fail.fatal should have been called with the error message'
+							);
+						})
+					);
 				},
 
 				'initial run uses default maintainers'() {
 					const dfd = this.async();
 
 					taskLoader(undefined, {
-						'initial': true
+						initial: true
 					});
 
-					shell.withArgs('npm whoami')
+					shell
+						.withArgs('npm whoami')
 						.returns(Promise.resolve({ stdout: 'dojo' }))
 						.withArgs('npm view . --json')
 						.throws();
 
-					runGruntTask('can-publish-check', dfd.callback(() => {
-						assert.isTrue(shell.calledOnce);
-					})).catch(dfd.rejectOnError(() => {
-						assert(false, 'Should have succeeded');
-					}));
+					runGruntTask(
+						'can-publish-check',
+						dfd.callback(() => {
+							assert.isTrue(shell.calledOnce);
+						})
+					).catch(
+						dfd.rejectOnError(() => {
+							assert(false, 'Should have succeeded');
+						})
+					);
 				}
 			}
 		};
 	})(),
-	'repo-is-clean-check': (function (): ObjectSuiteDescriptor {
+	'repo-is-clean-check': (function(): ObjectSuiteDescriptor {
 		let failStub: SinonStub;
 
 		return {
@@ -169,14 +211,18 @@ registerSuite('tasks/release', {
 					taskLoader();
 
 					// we need to mock the whole thing because
-					shell.withArgs('git status --porcelain')
-						.returns(Promise.resolve({ stdout: 'change' }));
+					shell.withArgs('git status --porcelain').returns(Promise.resolve({ stdout: 'change' }));
 
-					runGruntTask('repo-is-clean-check', dfd.rejectOnError(() => {
-						assert(false, 'should have failed');
-					})).catch(dfd.callback(() => {
-						assert.isTrue(failStub.calledWith('there are changes in the working tree'));
-					}));
+					runGruntTask(
+						'repo-is-clean-check',
+						dfd.rejectOnError(() => {
+							assert(false, 'should have failed');
+						})
+					).catch(
+						dfd.callback(() => {
+							assert.isTrue(failStub.calledWith('there are changes in the working tree'));
+						})
+					);
 				},
 
 				'not on default branch'() {
@@ -185,33 +231,41 @@ registerSuite('tasks/release', {
 					taskLoader();
 
 					// we need to mock the whole thing because
-					shell.withArgs('git status --porcelain')
+					shell
+						.withArgs('git status --porcelain')
 						.returns(Promise.resolve({ stdout: '' }))
 						.withArgs('git rev-parse --abbrev-ref HEAD')
 						.returns(Promise.resolve({ stdout: 'test' }));
 
-					runGruntTask('repo-is-clean-check', dfd.rejectOnError(() => {
-						assert(false, 'should have failed');
-					})).catch(dfd.callback(() => {
-						assert.isTrue(failStub.calledWith('not on master branch'));
-					}));
+					runGruntTask(
+						'repo-is-clean-check',
+						dfd.rejectOnError(() => {
+							assert(false, 'should have failed');
+						})
+					).catch(
+						dfd.callback(() => {
+							assert.isTrue(failStub.calledWith('not on master branch'));
+						})
+					);
 				},
 
-				'success'() {
+				success() {
 					const dfd = this.async();
 
 					taskLoader();
 
 					// we need to mock the whole thing because
-					shell.withArgs('git status --porcelain')
+					shell
+						.withArgs('git status --porcelain')
 						.returns(Promise.resolve({ stdout: '' }))
 						.withArgs('git rev-parse --abbrev-ref HEAD')
 						.returns(Promise.resolve({ stdout: 'master' }));
 
-					runGruntTask('repo-is-clean-check', dfd.callback(() => {
-					})).catch(dfd.rejectOnError(() => {
-						assert(false, 'should have succeeded');
-					}));
+					runGruntTask('repo-is-clean-check', dfd.callback(() => {})).catch(
+						dfd.rejectOnError(() => {
+							assert(false, 'should have succeeded');
+						})
+					);
 				}
 			}
 		};
@@ -231,15 +285,19 @@ registerSuite('tasks/release', {
 
 				taskLoader();
 
-				shell.withArgs('npm publish .')
-					.returns(Promise.resolve({ stdout: '' }));
+				shell.withArgs('npm publish .').returns(Promise.resolve({ stdout: '' }));
 
-				runGruntTask('release-publish', dfd.callback(() => {
-					assert.isTrue(shell.calledOnce);
-					assert.isTrue(shell.calledWith('npm publish . --tag next'));
-				})).catch(dfd.rejectOnError(() => {
-					assert(false, 'should have succeeded');
-				}));
+				runGruntTask(
+					'release-publish',
+					dfd.callback(() => {
+						assert.isTrue(shell.calledOnce);
+						assert.isTrue(shell.calledWith('npm publish . --tag next'));
+					})
+				).catch(
+					dfd.rejectOnError(() => {
+						assert(false, 'should have succeeded');
+					})
+				);
 			},
 
 			'with a tag'() {
@@ -249,15 +307,19 @@ registerSuite('tasks/release', {
 					tag: 'test'
 				});
 
-				shell.withArgs('npm publish . --tag test')
-					.returns(Promise.resolve({ stdout: '' }));
+				shell.withArgs('npm publish . --tag test').returns(Promise.resolve({ stdout: '' }));
 
-				runGruntTask('release-publish', dfd.callback(() => {
-					assert.isTrue(shell.calledOnce);
-					assert.isTrue(shell.calledWith('npm publish . --tag test'));
-				})).catch(dfd.rejectOnError(() => {
-					assert(false, 'should have succeeded');
-				}));
+				runGruntTask(
+					'release-publish',
+					dfd.callback(() => {
+						assert.isTrue(shell.calledOnce);
+						assert.isTrue(shell.calledWith('npm publish . --tag test'));
+					})
+				).catch(
+					dfd.rejectOnError(() => {
+						assert(false, 'should have succeeded');
+					})
+				);
 			},
 
 			'dry run'() {
@@ -267,21 +329,27 @@ registerSuite('tasks/release', {
 					'dry-run': true
 				});
 
-				shell.withArgs('npm publish .')
+				shell
+					.withArgs('npm publish .')
 					.returns(Promise.resolve({ stdout: '' }))
 					.withArgs('npm pack ../temp/')
 					.returns(Promise.resolve());
 
-				runGruntTask('release-publish', dfd.callback(() => {
-					assert.isTrue(shell.calledOnce);
-					assert.isTrue(shell.calledWith('npm pack ../temp/'));
-				})).catch(dfd.rejectOnError(() => {
-					assert(false, 'should have succeeded');
-				}));
+				runGruntTask(
+					'release-publish',
+					dfd.callback(() => {
+						assert.isTrue(shell.calledOnce);
+						assert.isTrue(shell.calledWith('npm pack ../temp/'));
+					})
+				).catch(
+					dfd.rejectOnError(() => {
+						assert(false, 'should have succeeded');
+					})
+				);
 			}
 		}
 	},
-	'release-version-pre-release-tag': (function (): ObjectSuiteDescriptor {
+	'release-version-pre-release-tag': (function(): ObjectSuiteDescriptor {
 		let failStub: SinonStub;
 
 		return {
@@ -304,18 +372,22 @@ registerSuite('tasks/release', {
 						'pre-release-tag': 'test'
 					});
 
-					shell.onFirstCall()
-						.returns(Promise.resolve({}));
+					shell.onFirstCall().returns(Promise.resolve({}));
 
-					runGruntTask('release-version-pre-release-tag', dfd.callback(() => {
-						assert.isTrue(shell.calledOnce);
+					runGruntTask(
+						'release-version-pre-release-tag',
+						dfd.callback(() => {
+							assert.isTrue(shell.calledOnce);
 
-						let command = (<any> shell).getCalls()[ 0 ].args[ 0 ];
+							let command = (<any>shell).getCalls()[0].args[0];
 
-						assert.isTrue(/npm version [\d.]+-test\.1/.test(command));
-					})).catch(dfd.rejectOnError(() => {
-						assert(false, 'should have succeeded');
-					}));
+							assert.isTrue(/npm version [\d.]+-test\.1/.test(command));
+						})
+					).catch(
+						dfd.rejectOnError(() => {
+							assert(false, 'should have succeeded');
+						})
+					);
 				},
 
 				'initial, dry run'() {
@@ -327,18 +399,22 @@ registerSuite('tasks/release', {
 						'pre-release-tag': 'test'
 					});
 
-					shell.onFirstCall()
-						.returns(Promise.resolve({}));
+					shell.onFirstCall().returns(Promise.resolve({}));
 
-					runGruntTask('release-version-pre-release-tag', dfd.callback(() => {
-						assert.isTrue(shell.calledOnce);
+					runGruntTask(
+						'release-version-pre-release-tag',
+						dfd.callback(() => {
+							assert.isTrue(shell.calledOnce);
 
-						let command = (<any> shell).getCalls()[ 0 ].args[ 0 ];
+							let command = (<any>shell).getCalls()[0].args[0];
 
-						assert.isTrue(/npm --no-git-tag-version version [\d.]+-test\.1/.test(command));
-					})).catch(dfd.rejectOnError(() => {
-						assert(false, 'should have succeeded');
-					}));
+							assert.isTrue(/npm --no-git-tag-version version [\d.]+-test\.1/.test(command));
+						})
+					).catch(
+						dfd.rejectOnError(() => {
+							assert(false, 'should have succeeded');
+						})
+					);
 				},
 				'regular w/ bad output'() {
 					const dfd = this.async();
@@ -347,16 +423,20 @@ registerSuite('tasks/release', {
 						'pre-release-tag': 'test'
 					});
 
-					shell.withArgs('npm view . --json')
-						.returns(Promise.resolve({ stdout: '' }));
+					shell.withArgs('npm view . --json').returns(Promise.resolve({ stdout: '' }));
 
-					runGruntTask('release-version-pre-release-tag', dfd.rejectOnError(() => {
-						assert(false, 'should have failed');
-					})).catch(dfd.callback(() => {
-						assert.isTrue(shell.calledOnce);
-					}));
+					runGruntTask(
+						'release-version-pre-release-tag',
+						dfd.rejectOnError(() => {
+							assert(false, 'should have failed');
+						})
+					).catch(
+						dfd.callback(() => {
+							assert.isTrue(shell.calledOnce);
+						})
+					);
 				},
-				'regular'() {
+				regular() {
 					const dfd = this.async();
 
 					taskLoader(undefined, {
@@ -367,28 +447,36 @@ registerSuite('tasks/release', {
 					const fullVersion = packageJson.version;
 					const justTheVersion = fullVersion.replace(/^([^\-]+).*$/g, '$1');
 
-					shell.onCall(0)
-						.returns(Promise.resolve({
-							stdout: JSON.stringify({
-								time: {
-									created: '1/1/2016',
-									modified: '1/2/2016',
-									[`${justTheVersion}-alpha.6`]: '2016-05-13T16:24:33.949Z',
-									[`${justTheVersion}-test.7`]: '2016-05-16T13:44:12.669Z'
-								}
+					shell
+						.onCall(0)
+						.returns(
+							Promise.resolve({
+								stdout: JSON.stringify({
+									time: {
+										created: '1/1/2016',
+										modified: '1/2/2016',
+										[`${justTheVersion}-alpha.6`]: '2016-05-13T16:24:33.949Z',
+										[`${justTheVersion}-test.7`]: '2016-05-16T13:44:12.669Z'
+									}
+								})
 							})
-						}))
+						)
 						.onCall(1)
 						.returns(Promise.resolve({}));
 
-					runGruntTask('release-version-pre-release-tag', dfd.callback(() => {
-						assert.isTrue(shell.calledTwice);
-						assert.equal(shell.firstCall.args[ 0 ], 'npm view . --json');
-						assert.equal(shell.secondCall.args[ 0 ], `npm version ${justTheVersion}-test.8`);
-					})).catch(dfd.rejectOnError((error: any) => {
-						console.log('*** ERRROR *', error);
-						assert(false, 'should have succeeded');
-					}));
+					runGruntTask(
+						'release-version-pre-release-tag',
+						dfd.callback(() => {
+							assert.isTrue(shell.calledTwice);
+							assert.equal(shell.firstCall.args[0], 'npm view . --json');
+							assert.equal(shell.secondCall.args[0], `npm version ${justTheVersion}-test.8`);
+						})
+					).catch(
+						dfd.rejectOnError((error: any) => {
+							console.log('*** ERRROR *', error);
+							assert(false, 'should have succeeded');
+						})
+					);
 				}
 			}
 		};
@@ -409,26 +497,30 @@ registerSuite('tasks/release', {
 					'release-version': '2.0.0-test.1'
 				});
 
-				shell.withArgs('npm --no-git-tag-version version 2.0.0-test.1')
-					.returns(Promise.resolve());
+				shell.withArgs('npm --no-git-tag-version version 2.0.0-test.1').returns(Promise.resolve());
 
-				runGruntTask('release-version-specific', dfd.callback(() => {
-					assert.isTrue(shell.calledOnce);
-				}));
+				runGruntTask(
+					'release-version-specific',
+					dfd.callback(() => {
+						assert.isTrue(shell.calledOnce);
+					})
+				);
 			},
-			'regular'() {
+			regular() {
 				const dfd = this.async();
 
 				taskLoader(undefined, {
 					'release-version': '2.0.0-test.1'
 				});
 
-				shell.withArgs('npm version 2.0.0-test.1')
-					.returns(Promise.resolve());
+				shell.withArgs('npm version 2.0.0-test.1').returns(Promise.resolve());
 
-				runGruntTask('release-version-specific', dfd.callback(() => {
-					assert.isTrue(shell.calledOnce);
-				}));
+				runGruntTask(
+					'release-version-specific',
+					dfd.callback(() => {
+						assert.isTrue(shell.calledOnce);
+					})
+				);
 			}
 		}
 	},
@@ -456,80 +548,86 @@ registerSuite('tasks/release', {
 
 				taskLoader();
 
-				shell.withArgs('git commit -am "Update package metadata"')
-					.returns(Promise.resolve({}));
+				shell.withArgs('git commit -am "Update package metadata"').returns(Promise.resolve({}));
 
-				runGruntTask('post-release-version', dfd.callback(() => {
-					assert.isTrue(shell.calledOnce);
+				runGruntTask(
+					'post-release-version',
+					dfd.callback(() => {
+						assert.isTrue(shell.calledOnce);
 
-					const newPackageJson = grunt.file.readJSON(path.join(process.cwd(), 'package.json'));
+						const newPackageJson = grunt.file.readJSON(path.join(process.cwd(), 'package.json'));
 
-					assert.equal(newPackageJson.version, originalPackageJson.version);
-				}));
+						assert.equal(newPackageJson.version, originalPackageJson.version);
+					})
+				);
 			},
 
 			'without next version'() {
 				const dfd = this.async();
 
-				taskLoader(undefined, {
-					'push-back': true
-				}, {
-					'parse-git-config': {
-						sync: function () {
-							return {
-								'remote "origin"': {
-									url: gitUrl
-								}
-							};
+				taskLoader(
+					undefined,
+					{
+						'push-back': true
+					},
+					{
+						'parse-git-config': {
+							sync: function() {
+								return {
+									'remote "origin"': {
+										url: gitUrl
+									}
+								};
+							}
 						}
 					}
-				});
-
-				shell.withArgs(
-					'git commit -am "Update package metadata"'
-				).returns(
-					Promise.resolve({})
-				).withArgs(
-					`git push ${gitUrl} master`
-				).returns(
-					Promise.resolve()
-				).withArgs(
-					`git push ${gitUrl} --tags`
-				).returns(
-					Promise.resolve()
 				);
 
-				runGruntTask('post-release-version', dfd.callback(() => {
-					assert.isTrue(shell.calledThrice);
-				}));
+				shell
+					.withArgs('git commit -am "Update package metadata"')
+					.returns(Promise.resolve({}))
+					.withArgs(`git push ${gitUrl} master`)
+					.returns(Promise.resolve())
+					.withArgs(`git push ${gitUrl} --tags`)
+					.returns(Promise.resolve());
+
+				runGruntTask(
+					'post-release-version',
+					dfd.callback(() => {
+						assert.isTrue(shell.calledThrice);
+					})
+				);
 			},
 
 			'no remotes'() {
 				const dfd = this.async();
 
-				taskLoader(undefined, {
-					'push-back': true
-				}, {
-					'parse-git-config': {
-						sync: function () {
-							return {
-								'remote "origin"': {
-									url: 'test'
-								}
-							};
+				taskLoader(
+					undefined,
+					{
+						'push-back': true
+					},
+					{
+						'parse-git-config': {
+							sync: function() {
+								return {
+									'remote "origin"': {
+										url: 'test'
+									}
+								};
+							}
 						}
 					}
-				});
-
-				shell.withArgs(
-					'git commit -am "Update package metadata"'
-				).returns(
-					Promise.resolve({})
 				);
 
-				runGruntTask('post-release-version', dfd.callback(() => {
-					assert.isTrue(shell.calledOnce);
-				}));
+				shell.withArgs('git commit -am "Update package metadata"').returns(Promise.resolve({}));
+
+				runGruntTask(
+					'post-release-version',
+					dfd.callback(() => {
+						assert.isTrue(shell.calledOnce);
+					})
+				);
 			},
 
 			'next version'() {
@@ -539,20 +637,22 @@ registerSuite('tasks/release', {
 					'next-version': 'test-version'
 				});
 
-				shell.withArgs('git commit -am "Update package metadata"')
-					.returns(Promise.resolve({}));
+				shell.withArgs('git commit -am "Update package metadata"').returns(Promise.resolve({}));
 
-				runGruntTask('post-release-version', dfd.callback(() => {
-					assert.isTrue(shell.calledOnce);
+				runGruntTask(
+					'post-release-version',
+					dfd.callback(() => {
+						assert.isTrue(shell.calledOnce);
 
-					const newPackageJson = grunt.file.readJSON(path.join(process.cwd(), 'package.json'));
+						const newPackageJson = grunt.file.readJSON(path.join(process.cwd(), 'package.json'));
 
-					assert.equal(newPackageJson.version, 'test-version');
-				}));
+						assert.equal(newPackageJson.version, 'test-version');
+					})
+				);
 			}
 		}
 	},
-	'release-publish-flat': (function () {
+	'release-publish-flat': (function() {
 		let runStub: SinonStub;
 
 		return {
@@ -581,11 +681,16 @@ registerSuite('tasks/release', {
 			},
 
 			tests: {
-				'run'() {
+				run() {
 					runGruntTask('release-publish-flat');
 
 					assert.isTrue(runStub.calledOnce);
-					assert.deepEqual((<any> runStub).getCalls()[ 0 ].args[ 0 ], [ 'customise-dist-output', 'copy:temp', 'release-publish', 'clean:temp' ]);
+					assert.deepEqual((<any>runStub).getCalls()[0].args[0], [
+						'customise-dist-output',
+						'copy:temp',
+						'release-publish',
+						'clean:temp'
+					]);
 
 					const newPackageJson = grunt.file.readJSON(path.join('temp', 'package.json'));
 
@@ -609,7 +714,7 @@ registerSuite('tasks/release', {
 			}
 		};
 	})(),
-	release: (function () {
+	release: (function() {
 		let failStub: SinonStub;
 		let runStub: SinonStub;
 
@@ -668,7 +773,7 @@ registerSuite('tasks/release', {
 					runGruntTask('release');
 
 					assert.isTrue(runStub.calledOnce);
-					assert.deepEqual((<any> runStub).getCalls()[ 0 ].args[ 0 ], [
+					assert.deepEqual((<any>runStub).getCalls()[0].args[0], [
 						'can-publish-check',
 						'repo-is-clean-check',
 						'dist',
@@ -688,7 +793,7 @@ registerSuite('tasks/release', {
 					runGruntTask('release');
 
 					assert.isTrue(runStub.calledOnce);
-					assert.deepEqual((<any> runStub).getCalls()[ 0 ].args[ 0 ], [
+					assert.deepEqual((<any>runStub).getCalls()[0].args[0], [
 						'dist',
 						'release-version-pre-release-tag',
 						'release-publish-flat',
@@ -705,7 +810,7 @@ registerSuite('tasks/release', {
 					runGruntTask('release');
 
 					assert.isTrue(runStub.calledOnce);
-					assert.deepEqual((<any> runStub).getCalls()[ 0 ].args[ 0 ], [
+					assert.deepEqual((<any>runStub).getCalls()[0].args[0], [
 						'can-publish-check',
 						'repo-is-clean-check',
 						'dist',

--- a/tests/unit/tasks/rename.ts
+++ b/tests/unit/tasks/rename.ts
@@ -13,7 +13,9 @@ import {
 	createDummyFile,
 	createDummyDirectory,
 	fileExistsInInputDirectory,
-	fileExistsInOutputDirectory, cleanInputDirectory, cleanOutputDirectory
+	fileExistsInOutputDirectory,
+	cleanInputDirectory,
+	cleanOutputDirectory
 } from '../util';
 
 const inputDirectory = getInputDirectory();
@@ -57,12 +59,24 @@ registerSuite('tasks/rename', {
 
 					runGruntTask('rename:textFiles');
 
-					assert.isFalse(fileExistsInInputDirectory('file1.txt'), 'file1.txt should not be in input directory');
-					assert.isTrue(fileExistsInOutputDirectory('file1.txt'), 'file1.txt should have been moved to output directory');
+					assert.isFalse(
+						fileExistsInInputDirectory('file1.txt'),
+						'file1.txt should not be in input directory'
+					);
+					assert.isTrue(
+						fileExistsInOutputDirectory('file1.txt'),
+						'file1.txt should have been moved to output directory'
+					);
 					assert.isTrue(fileExistsInInputDirectory('file2'), 'file2 should still be in input directory');
 					assert.isFalse(fileExistsInOutputDirectory('file2'), 'file2 should not be in output directory');
-					assert.isFalse(fileExistsInInputDirectory('dir.txt'), 'dir.txt directory should not be in input directory');
-					assert.isTrue(fileExistsInOutputDirectory('dir.txt'), 'dir.txt directory should be in output directory');
+					assert.isFalse(
+						fileExistsInInputDirectory('dir.txt'),
+						'dir.txt directory should not be in input directory'
+					);
+					assert.isTrue(
+						fileExistsInOutputDirectory('dir.txt'),
+						'dir.txt directory should be in output directory'
+					);
 				}
 			}
 		}

--- a/tests/unit/tasks/repl.ts
+++ b/tests/unit/tasks/repl.ts
@@ -5,8 +5,7 @@ import * as grunt from 'grunt';
 import { loadTasks, unloadTasks, runGruntTask } from '../util';
 
 let fakeRepl: any = {};
-const fakeDojoRequire = function () {
-};
+const fakeDojoRequire = function() {};
 
 registerSuite('tasks/repl', {
 	before() {
@@ -53,17 +52,20 @@ registerSuite('tasks/repl', {
 
 			runGruntTask('repl');
 
-			setTimeout(dfd.callback(() => {
-				assert.isNotNull(fakeRepl.require);
-				assert.isNotNull(fakeRepl.nodeRequire);
+			setTimeout(
+				dfd.callback(() => {
+					assert.isNotNull(fakeRepl.require);
+					assert.isNotNull(fakeRepl.nodeRequire);
 
-				assert.equal(fakeRepl.require, fakeDojoRequire);
-				assert.notEqual(fakeRepl.nodeRequire, fakeDojoRequire);
+					assert.equal(fakeRepl.require, fakeDojoRequire);
+					assert.notEqual(fakeRepl.nodeRequire, fakeDojoRequire);
 
-				let testPackage = fakeRepl.nodeRequire('test-package');
-				assert.deepEqual(testPackage, { hello: 'world' });
-				assert.equal(fakeRepl.nodeRequire.resolve('test-package'), './base-url/test-package');
-			}), 10);
+					let testPackage = fakeRepl.nodeRequire('test-package');
+					assert.deepEqual(testPackage, { hello: 'world' });
+					assert.equal(fakeRepl.nodeRequire.resolve('test-package'), './base-url/test-package');
+				}),
+				10
+			);
 		}
 	}
 });

--- a/tests/unit/tasks/run.ts
+++ b/tests/unit/tasks/run.ts
@@ -31,26 +31,30 @@ registerSuite('tasks/run', {
 		runsDefault() {
 			const dfd = this.async(1000);
 
-			runGruntTask('run', () => {
-			});
+			runGruntTask('run', () => {});
 
-			setTimeout(dfd.callback(() => {
-				assert.isTrue(requireStub.calledOnce);
-				assert.deepEqual(requireStub.firstCall.args[ 0 ], [ 'src/main' ]);
-			}), 100);
+			setTimeout(
+				dfd.callback(() => {
+					assert.isTrue(requireStub.calledOnce);
+					assert.deepEqual(requireStub.firstCall.args[0], ['src/main']);
+				}),
+				100
+			);
 		},
 		runsArgument() {
 			const dfd = this.async(1000);
 
 			grunt.option('main', 'my-main');
 
-			runGruntTask('run', () => {
-			});
+			runGruntTask('run', () => {});
 
-			setTimeout(dfd.callback(() => {
-				assert.isTrue(requireStub.calledOnce);
-				assert.deepEqual(requireStub.firstCall.args[ 0 ], [ 'my-main' ]);
-			}), 100);
+			setTimeout(
+				dfd.callback(() => {
+					assert.isTrue(requireStub.calledOnce);
+					assert.deepEqual(requireStub.firstCall.args[0], ['my-main']);
+				}),
+				100
+			);
 		}
 	}
 });

--- a/tests/unit/tasks/tcm.ts
+++ b/tests/unit/tasks/tcm.ts
@@ -17,14 +17,16 @@ registerSuite('tasks/tcm', {
 		unloadTasks();
 	},
 	tests: {
-		'npm': {
+		npm: {
 			beforeEach() {
 				grunt.initConfig({});
-				mockGlob = stub().callsArgWith(1, null,  [ 'one', 'two', 'three' ]);
+				mockGlob = stub().callsArgWith(1, null, ['one', 'two', 'three']);
 				mockWriteFile = stub().returns(Promise.resolve());
-				mockCreate = stub().returns(Promise.resolve({
-					writeFile: mockWriteFile
-				}));
+				mockCreate = stub().returns(
+					Promise.resolve({
+						writeFile: mockWriteFile
+					})
+				);
 				mockCreator = stub().returns({
 					create: mockCreate
 				});
@@ -36,27 +38,32 @@ registerSuite('tasks/tcm', {
 						glob: mockGlob,
 						'typed-css-modules': mockCreator
 					});
-					runGruntTask('tcm', deferred.callback(() => {
-						assert.isTrue(mockGlob.calledOnce);
-						assert.equal(
-							mockGlob.firstCall.args[0],
-							'src/**/*.m.css',
-							'Should have searched for all .m.css files in src directory'
-						);
-						assert.isTrue(mockCreator.calledOnce);
-						assert.deepEqual(mockCreator.firstCall.args,  [ {
-							rootDir: process.cwd(),
-							searchDir: 'src'
-						} ]);
+					runGruntTask(
+						'tcm',
+						deferred.callback(() => {
+							assert.isTrue(mockGlob.calledOnce);
+							assert.equal(
+								mockGlob.firstCall.args[0],
+								'src/**/*.m.css',
+								'Should have searched for all .m.css files in src directory'
+							);
+							assert.isTrue(mockCreator.calledOnce);
+							assert.deepEqual(mockCreator.firstCall.args, [
+								{
+									rootDir: process.cwd(),
+									searchDir: 'src'
+								}
+							]);
 
-						assert.equal(mockCreate.callCount, 3, 'Should have called create for each file');
-						assert.deepEqual(
-							mockCreate.args,
-							[ [ 'one' ], [ 'two' ], [ 'three' ] ],
-							'Should have called create for each file'
-						);
-						assert.equal(mockWriteFile.callCount, 3, 'Should have called writeFile for each file');
-					}));
+							assert.equal(mockCreate.callCount, 3, 'Should have called create for each file');
+							assert.deepEqual(
+								mockCreate.args,
+								[['one'], ['two'], ['three']],
+								'Should have called create for each file'
+							);
+							assert.equal(mockWriteFile.callCount, 3, 'Should have called writeFile for each file');
+						})
+					);
 				},
 
 				'should fail if there is an error'() {
@@ -66,23 +73,31 @@ registerSuite('tasks/tcm', {
 						glob: mockGlob,
 						'typed-css-modules': mockCreator
 					});
-					runGruntTask('tcm', deferred.callback((error: any) => {
-						assert.isTrue(mockGlob.calledOnce);
-						assert.equal(
-							mockGlob.firstCall.args[0],
-							'src/**/*.m.css',
-							'Should have searched for all .m.css files in src directory'
-						);
-						assert.isTrue(mockCreator.calledOnce);
-						assert.deepEqual(mockCreator.firstCall.args,  [ {
-							rootDir: process.cwd(),
-							searchDir: 'src'
-						} ]);
+					runGruntTask(
+						'tcm',
+						deferred.callback((error: any) => {
+							assert.isTrue(mockGlob.calledOnce);
+							assert.equal(
+								mockGlob.firstCall.args[0],
+								'src/**/*.m.css',
+								'Should have searched for all .m.css files in src directory'
+							);
+							assert.isTrue(mockCreator.calledOnce);
+							assert.deepEqual(mockCreator.firstCall.args, [
+								{
+									rootDir: process.cwd(),
+									searchDir: 'src'
+								}
+							]);
 
-						assert.isFalse(mockCreate.called, 'Should not have called create when there was an error');
-						assert.isFalse(mockWriteFile.called, 'Should not have called write file when there was an error');
-						assert.equal(error, 'error', 'Should have passed returned error to callback');
-					}));
+							assert.isFalse(mockCreate.called, 'Should not have called create when there was an error');
+							assert.isFalse(
+								mockWriteFile.called,
+								'Should not have called write file when there was an error'
+							);
+							assert.equal(error, 'error', 'Should have passed returned error to callback');
+						})
+					);
 				}
 			}
 		}

--- a/tests/unit/tasks/ts.ts
+++ b/tests/unit/tasks/ts.ts
@@ -10,7 +10,7 @@ import {
 	loadTasks,
 	prepareOutputDirectory,
 	runGruntTask,
-	unloadTasks,
+	unloadTasks
 } from '../util';
 
 const outputPath = getOutputDirectory();
@@ -45,14 +45,14 @@ registerSuite('tasks/ts', {
 		grunt.initConfig({
 			distDirectory: outputPath,
 			tsconfig: {
-				'compilerOptions': {
-					'inlineSourceMap': true,
-					'inlineSources': true,
-					'listFiles': true,
-					'module': 'commonjs',
-					'noImplicitAny': true,
-					'pretty': true,
-					'target': 'es6'
+				compilerOptions: {
+					inlineSourceMap: true,
+					inlineSources: true,
+					listFiles: true,
+					module: 'commonjs',
+					noImplicitAny: true,
+					pretty: true,
+					target: 'es6'
 				}
 			},
 			ts: {
@@ -92,11 +92,10 @@ registerSuite('tasks/ts', {
 			});
 
 			assert.isTrue(run.calledOnce);
-			assert.deepEqual(run.firstCall.args[ 0 ], [ 'ts:dev' ]);
+			assert.deepEqual(run.firstCall.args[0], ['ts:dev']);
 		},
 
 		dev() {
-
 			runGruntTask('dojo-ts:dev');
 
 			assert.deepEqual(grunt.config('ts.dev'), {
@@ -107,14 +106,14 @@ registerSuite('tasks/ts', {
 			});
 
 			assert.isTrue(run.calledOnce);
-			assert.deepEqual(run.firstCall.args[ 0 ], [ 'ts:dev' ]);
+			assert.deepEqual(run.firstCall.args[0], ['ts:dev']);
 		},
 
 		dist() {
 			runGruntTask('dojo-ts:dist');
 
 			assert.isTrue(run.calledOnce);
-			assert.deepEqual(run.firstCall.args[ 0 ], [ 'dojo-ts:umd', 'merge-dist' ]);
+			assert.deepEqual(run.firstCall.args[0], ['dojo-ts:umd', 'merge-dist']);
 
 			expand.onFirstCall().returns(['dist/umd/file1.js']);
 			expand.onSecondCall().returns(['dist/esm/file1.mjs']);
@@ -129,14 +128,14 @@ registerSuite('tasks/ts', {
 			grunt.initConfig({
 				distDirectory: outputPath,
 				tsconfig: {
-					'compilerOptions': {
-						'inlineSourceMap': true,
-						'inlineSources': true,
-						'listFiles': true,
-						'module': 'commonjs',
-						'noImplicitAny': true,
-						'pretty': true,
-						'target': 'es6'
+					compilerOptions: {
+						inlineSourceMap: true,
+						inlineSources: true,
+						listFiles: true,
+						module: 'commonjs',
+						noImplicitAny: true,
+						pretty: true,
+						target: 'es6'
 					}
 				}
 			});
@@ -175,8 +174,11 @@ registerSuite('tasks/ts', {
 			assert.isTrue(rename.calledWith('file.js.map', 'file.mjs.map'));
 			assert.isTrue(write.calledWith('file.mjs.map'));
 
-			assert.deepEqual(write.args[1][1], `some file
-//# sourceMappingURL=RouterInjector.mjs.map`);
+			assert.deepEqual(
+				write.args[1][1],
+				`some file
+//# sourceMappingURL=RouterInjector.mjs.map`
+			);
 
 			assert.deepEqual(JSON.parse(write.args[2][1]), {
 				file: 'file.mjs',
@@ -195,7 +197,7 @@ registerSuite('tasks/ts', {
 			});
 
 			assert.isTrue(run.calledOnce);
-			assert.deepEqual(run.firstCall.args[ 0 ], [ 'ts:custom', 'clean:customTsconfig' ]);
+			assert.deepEqual(run.firstCall.args[0], ['ts:custom', 'clean:customTsconfig']);
 
 			assert.isTrue(write.calledOnce);
 			assert.isTrue(write.calledWith('.tsconfigcustom.json'));

--- a/tests/unit/tasks/typedoc.ts
+++ b/tests/unit/tasks/typedoc.ts
@@ -43,7 +43,6 @@ function escape(str: string): string {
 }
 
 registerSuite('tasks/typedoc', {
-
 	before() {
 		execSync = spy((command: string) => {
 			if (/git checkout/.test(command) && failInitialCheckout) {
@@ -56,23 +55,23 @@ registerSuite('tasks/typedoc', {
 			publish: stub(),
 			commit: stub()
 		};
-		publisherConstructor = spy(function () {
+		publisherConstructor = spy(function() {
 			return publisher;
 		});
 
 		loadTasks({
-			'shelljs': {
+			shelljs: {
 				config: {},
 				cp,
 				rm,
 				touch
 			},
 			'./util/process': {
-				'exec': execSync,
-				'spawn': spawnStub
+				exec: execSync,
+				spawn: spawnStub
 			},
 			'./util/Publisher': {
-				'default': publisherConstructor
+				default: publisherConstructor
 			}
 		});
 
@@ -80,7 +79,7 @@ registerSuite('tasks/typedoc', {
 		run = stub(grunt.task, 'run');
 		write = spy(grunt.file, 'write');
 		expandMapping = stub(grunt.file, 'expandMapping', (patterns: string[], base: string) => {
-			return [ 'foo' ];
+			return ['foo'];
 		});
 		readJSON = stub(grunt.file, 'readJSON', (filename: string) => {
 			return {};
@@ -153,8 +152,9 @@ registerSuite('tasks/typedoc', {
 			const command = execSync.args[0][0];
 			const matcher = new RegExp(
 				`node "[^"]+${escape(sep)}typedoc" --mode "modules" --excludeExternals --excludeNotExported ` +
-				`--tsconfig "${escape(join(outputPath, 'tsconfig.json'))}" ` +
-				`--logger "none" --out "${escape(apiDocDirectory)}"`);
+					`--tsconfig "${escape(join(outputPath, 'tsconfig.json'))}" ` +
+					`--logger "none" --out "${escape(apiDocDirectory)}"`
+			);
 			assert.match(command, matcher, 'Unexpected typedoc command line');
 			assert.strictEqual(write.callCount, 0, 'Nothing should have been written');
 			assert.strictEqual(execSync.callCount, 1, 'Unexpected number of exec calls');

--- a/tests/unit/tasks/uploadCoverage.ts
+++ b/tests/unit/tasks/uploadCoverage.ts
@@ -18,13 +18,13 @@ registerSuite('tasks/uploadCoverage', {
 			'codecov.io/lib/sendToCodeCov.io': sendCodeCov
 		});
 
-		read = stub(grunt.file, 'read').withArgs(
-			coverageFileName
-		).returns(
-			JSON.stringify({
-				hello: 'world'
-			})
-		);
+		read = stub(grunt.file, 'read')
+			.withArgs(coverageFileName)
+			.returns(
+				JSON.stringify({
+					hello: 'world'
+				})
+			);
 	},
 	after() {
 		unloadTasks();
@@ -33,10 +33,13 @@ registerSuite('tasks/uploadCoverage', {
 		propagatesReturnValue() {
 			const dfd = this.async();
 
-			runGruntTask('uploadCoverage', dfd.callback(() => {
-				assert.isTrue(sendCodeCov.calledOnce);
-				assert.deepEqual(JSON.parse(sendCodeCov.firstCall.args[ 0 ]), { hello: 'world' });
-			}));
+			runGruntTask(
+				'uploadCoverage',
+				dfd.callback(() => {
+					assert.isTrue(sendCodeCov.calledOnce);
+					assert.deepEqual(JSON.parse(sendCodeCov.firstCall.args[0]), { hello: 'world' });
+				})
+			);
 		}
 	}
 });

--- a/tests/unit/tasks/util/Publisher.ts
+++ b/tests/unit/tasks/util/Publisher.ts
@@ -16,10 +16,9 @@ const log = { writeln: stub() };
 let Publisher: typeof PublisherInstance;
 
 registerSuite('tasks/util/Publisher', {
-
 	before() {
 		const mocks = {
-			'shelljs': {
+			shelljs: {
 				config: {},
 				cp: cpStub,
 				rm: rmStub
@@ -29,8 +28,8 @@ registerSuite('tasks/util/Publisher', {
 				existsSync: existsStub
 			},
 			'./process': {
-				'exec': execStub,
-				'spawn': spawnStub
+				exec: execStub,
+				spawn: spawnStub
 			}
 		};
 		Publisher = loadModule('../../../../tasks/util/Publisher', require, mocks);

--- a/tests/unit/tasks/util/postcss.ts
+++ b/tests/unit/tasks/util/postcss.ts
@@ -16,28 +16,27 @@ const parseStub = stub().returns('');
 const dirnameStub = stub().returns('');
 const joinStub = stub().returns('');
 const umdWrapperStub = stub().returns('');
-const packageJsonStub = stub().returns({name: '@owner/widgets'});
+const packageJsonStub = stub().returns({ name: '@owner/widgets' });
 const writeFileStub = stub();
 
 registerSuite('tasks/util/postcss', {
-
 	before() {
 		const mocks = {
-			'cssnano': cssNanoModuleStub,
+			cssnano: cssNanoModuleStub,
 			'postcss-modules': postCssModulesStub,
 			'postcss-import': postCssImportStub,
 			'postcss-cssnext': postCssNextStub,
-			'path': {
-				'resolve': resolveStub,
-				'relative': relativeStub,
-				'basename': basenameStub,
-				'parse': parseStub,
-				'dirname': dirnameStub,
-				'join': joinStub
+			path: {
+				resolve: resolveStub,
+				relative: relativeStub,
+				basename: basenameStub,
+				parse: parseStub,
+				dirname: dirnameStub,
+				join: joinStub
 			},
 			'./umdWrapper': umdWrapperStub,
-			'fs': {
-				'writeFileSync': writeFileStub
+			fs: {
+				writeFileSync: writeFileStub
 			}
 		};
 
@@ -66,7 +65,7 @@ registerSuite('tasks/util/postcss', {
 
 	tests: {
 		createProcessors: {
-			'order'() {
+			order() {
 				const processors = postCssUtil.createProcessors({
 					packageJson: packageJsonStub(),
 					dest: ''
@@ -87,15 +86,12 @@ registerSuite('tasks/util/postcss', {
 					cwd: ''
 				});
 				assert.isTrue(postCssNextStub.calledOnce);
-				const [ autoPrefixrConfig ] = postCssNextStub.firstCall.args;
+				const [autoPrefixrConfig] = postCssNextStub.firstCall.args;
 
 				assert.deepEqual(autoPrefixrConfig, {
 					features: {
 						autoprefixer: {
-							browsers: [
-							'last 2 versions',
-							'ie >= 11'
-							]
+							browsers: ['last 2 versions', 'ie >= 11']
 						}
 					}
 				});
@@ -114,7 +110,7 @@ registerSuite('tasks/util/postcss', {
 						cwd: '',
 						dist: false
 					});
-					const [{generateScopedName}] = postCssModulesStub.firstCall.args;
+					const [{ generateScopedName }] = postCssModulesStub.firstCall.args;
 					assert.equal(generateScopedName, '[name]__[local]__[hash:base64:5]');
 				},
 				'generate hash only scoped name for dist'() {
@@ -124,11 +120,11 @@ registerSuite('tasks/util/postcss', {
 						cwd: '',
 						dist: true
 					});
-					const [{generateScopedName}] = postCssModulesStub.firstCall.args;
+					const [{ generateScopedName }] = postCssModulesStub.firstCall.args;
 					assert.equal(generateScopedName, '[hash:base64:8]');
 				}
 			},
-			'getJSON': {
+			getJSON: {
 				'should create output file with .js extension'() {
 					const cssFileName = 'testFileName.m.css';
 					const jsonParam = {};
@@ -140,7 +136,7 @@ registerSuite('tasks/util/postcss', {
 						cwd: ''
 					});
 
-					const getJSON = (<any> postCssModulesStub.firstCall.args[0]).getJSON;
+					const getJSON = (<any>postCssModulesStub.firstCall.args[0]).getJSON;
 					getJSON(cssFileName, jsonParam);
 
 					assert.isTrue(writeFileStub.calledOnce);
@@ -157,7 +153,7 @@ registerSuite('tasks/util/postcss', {
 						cwd: ''
 					});
 
-					const getJSON = (<any> postCssModulesStub.firstCall.args[0]).getJSON;
+					const getJSON = (<any>postCssModulesStub.firstCall.args[0]).getJSON;
 
 					getJSON(cssFileName, jsonParam);
 					assert.isTrue(basenameStub.calledOnce);
@@ -174,7 +170,7 @@ registerSuite('tasks/util/postcss', {
 						cwd: ''
 					});
 
-					const getJSON = (<any> postCssModulesStub.firstCall.args[0]).getJSON;
+					const getJSON = (<any>postCssModulesStub.firstCall.args[0]).getJSON;
 
 					getJSON(cssFileName, jsonParam);
 					assert.isTrue(umdWrapperStub.calledOnce);

--- a/tests/unit/tasks/util/process.ts
+++ b/tests/unit/tasks/util/process.ts
@@ -13,12 +13,11 @@ function assertDefaultOptions(options: any) {
 	assert.strictEqual(options.stdio, 'inherit');
 }
 registerSuite('tasks/util/process', {
-
 	before() {
 		const mocks = {
-			'child_process': {
-				'execSync': execStub,
-				'spawnSync': spawnStub
+			child_process: {
+				execSync: execStub,
+				spawnSync: spawnStub
 			}
 		};
 
@@ -46,7 +45,7 @@ registerSuite('tasks/util/process', {
 
 		spawn() {
 			const command = 'ls';
-			const args = [ '-al' ];
+			const args = ['-al'];
 			process.spawn(command, args);
 			assert.isTrue(spawnStub.calledOnce);
 			assert.strictEqual(spawnStub.lastCall.args[0], command);
@@ -56,7 +55,7 @@ registerSuite('tasks/util/process', {
 		},
 
 		options: {
-			'default'() {
+			default() {
 				const command = 'cmd';
 				process.exec(command);
 				assert.strictEqual(execStub.lastCall.args[0], command);

--- a/tests/unit/util.ts
+++ b/tests/unit/util.ts
@@ -49,17 +49,20 @@ export function cleanOutputDirectory() {
 }
 
 export function runGruntTask(taskName: string, callback?: () => void) {
-	const task = (<any> grunt.task)._taskPlusArgs(taskName);
+	const task = (<any>grunt.task)._taskPlusArgs(taskName);
 
-	return task.task.fn.apply({
-		nameArgs: task.nameArgs,
-		name: task.task.name,
-		args: task.args,
-		flags: task.flags,
-		async: function () {
-			return callback;
-		}
-	}, task.args);
+	return task.task.fn.apply(
+		{
+			nameArgs: task.nameArgs,
+			name: task.task.name,
+			args: task.args,
+			flags: task.flags,
+			async: function() {
+				return callback;
+			}
+		},
+		task.args
+	);
 }
 
 export function fileExistsInOutputDirectory(fileName: string) {
@@ -109,8 +112,7 @@ export function loadTasks(mocks?: MockList, options?: TaskLoadingOptions) {
 		registerMockList(mocks);
 	}
 
-	grunt.registerTask('clean', 'Clean mock task', () => {
-	});
+	grunt.registerTask('clean', 'Clean mock task', () => {});
 
 	const packageJson = grunt.file.readJSON('package.json');
 
@@ -118,13 +120,12 @@ export function loadTasks(mocks?: MockList, options?: TaskLoadingOptions) {
 		packageJson.peerDependencies = options.peerDependencies;
 	}
 
-	grunt.file.expand([ 'tasks/*.js' ]).forEach((fileName) => {
+	grunt.file.expand(['tasks/*.js']).forEach((fileName) => {
 		require('../../' + fileName.substr(0, fileName.length - 3))(grunt, packageJson);
 	});
 
 	// suppress grunt logging
-	(<any> grunt.log)._write = () => {
-	};
+	(<any>grunt.log)._write = () => {};
 }
 
 export function unloadTasks() {

--- a/tslint.json
+++ b/tslint.json
@@ -32,15 +32,12 @@
 		"no-trailing-whitespace": true,
 		"no-unreachable": true,
 		"no-unused-expression": false,
-		"no-unused-variable": true,
 		"no-use-before-declare": false,
 		"no-var-keyword": true,
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
-		"semicolon": true,
 		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -54,8 +51,6 @@
 			"property-declaration": "nospace",
 			"variable-declaration": "nospace"
 		} ],
-		"use-strict": false,
-		"variable-name": false,
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": false
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase.

Related to https://github.com/dojo/meta/issues/206