### PR TITLE
Adds hook into the release task to be able to customise the dist files

### DIFF
--- a/tasks/release.ts
+++ b/tasks/release.ts
@@ -205,7 +205,7 @@ export = function(grunt: IGrunt, packageJson: any) {
 		grunt.log.subhead('making flat package...');
 		const pkg = grunt.file.readJSON(path.join(packagePath, 'package.json'));
 		const dist = grunt.config('copy.staticDefinitionFiles-dist.dest');
-		const tasks = ['copy:temp', 'release-publish', 'clean:temp'];
+		const tasks = ['customise-dist-output', 'copy:temp', 'release-publish', 'clean:temp'];
 
 		grunt.config.merge({
 			copy: { temp: { expand: true, cwd: dist, src: '**', dest: temp } },
@@ -221,6 +221,8 @@ export = function(grunt: IGrunt, packageJson: any) {
 		});
 		grunt.task.run(tasks);
 	});
+
+	grunt.registerTask('customise-dist-output', () => {});
 
 	grunt.registerTask('release', 'release', function () {
 		grunt.option('remove-links', true);

--- a/tests/unit/tasks/release.ts
+++ b/tests/unit/tasks/release.ts
@@ -585,7 +585,7 @@ registerSuite('tasks/release', {
 					runGruntTask('release-publish-flat');
 
 					assert.isTrue(runStub.calledOnce);
-					assert.deepEqual((<any> runStub).getCalls()[ 0 ].args[ 0 ], [ 'copy:temp', 'release-publish', 'clean:temp' ]);
+					assert.deepEqual((<any> runStub).getCalls()[ 0 ].args[ 0 ], [ 'customise-dist-output', 'copy:temp', 'release-publish', 'clean:temp' ]);
 
 					const newPackageJson = grunt.file.readJSON(path.join('temp', 'package.json'));
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds a hook point that consumers can override to customise the output that is packaged as the distributable.