### PR TITLE
Pass reduceIdents: false to cssnano

### DIFF
--- a/tasks/util/postcss.ts
+++ b/tasks/util/postcss.ts
@@ -38,6 +38,6 @@ export function createProcessors({
 			}
 		}),
 		// autoprefixer included in cssnext
-		cssNano({ autoprefixer: false, zindex: false })
+		cssNano({ autoprefixer: false, zindex: false, reduceIdents: false })
 	];
 }

--- a/tests/unit/tasks/util/postcss.ts
+++ b/tests/unit/tasks/util/postcss.ts
@@ -99,7 +99,8 @@ registerSuite('tasks/util/postcss', {
 				assert.isTrue(cssNanoModuleStub.calledOnce);
 				assert.deepEqual(cssNanoModuleStub.firstCall.args[0], {
 					autoprefixer: false,
-					zindex: false
+					zindex: false,
+					reduceIdents: false
 				});
 			},
 			'generate scoped name': {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Prevent `cssnano` from minifying `@keyframes` identifiers by passing `reduceIdents: false` to it

Resolves #197 