### PR TITLE
Do not normalise urls with css-nano

### DIFF
--- a/tasks/util/postcss.ts
+++ b/tasks/util/postcss.ts
@@ -38,6 +38,6 @@ export function createProcessors({
 			}
 		}),
 		// autoprefixer included in cssnext
-		cssNano({ autoprefixer: false, zindex: false, reduceIdents: false })
+		cssNano({ autoprefixer: false, zindex: false, reduceIdents: false, urlOptimize: false })
 	];
 }

--- a/tasks/util/postcss.ts
+++ b/tasks/util/postcss.ts
@@ -38,6 +38,6 @@ export function createProcessors({
 			}
 		}),
 		// autoprefixer included in cssnext
-		cssNano({ autoprefixer: false, zindex: false, reduceIdents: false, urlOptimize: false })
+		cssNano({ autoprefixer: false, zindex: false, reduceIdents: false, normalizeUrl: false })
 	];
 }

--- a/tests/unit/tasks/util/postcss.ts
+++ b/tests/unit/tasks/util/postcss.ts
@@ -100,7 +100,8 @@ registerSuite('tasks/util/postcss', {
 				assert.deepEqual(cssNanoModuleStub.firstCall.args[0], {
 					autoprefixer: false,
 					zindex: false,
-					reduceIdents: false
+					reduceIdents: false,
+					urlOptimize: false
 				});
 			},
 			'generate scoped name': {

--- a/tests/unit/tasks/util/postcss.ts
+++ b/tests/unit/tasks/util/postcss.ts
@@ -101,7 +101,7 @@ registerSuite('tasks/util/postcss', {
 					autoprefixer: false,
 					zindex: false,
 					reduceIdents: false,
-					urlOptimize: false
+					normalizeUrl: false
 				});
 			},
 			'generate scoped name': {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Turn url normalisation off
